### PR TITLE
Fix Marking Favorites from Look Ahead

### DIFF
--- a/Classes/LookAheadViewController.swift
+++ b/Classes/LookAheadViewController.swift
@@ -321,6 +321,10 @@ class LookAheadViewController: UIViewController, UITableViewDataSource, UITableV
         menuVC.eatery = eatery
         menuVC.displayedDate = dates[selectedDateIndex] as! NSDate
         menuVC.selectedMeal = getSelectedMeal(eatery)
+        if let navigationController = self.navigationController {
+            let delegateIndex = navigationController.viewControllers.count - 2
+            menuVC.delegate = navigationController.viewControllers[delegateIndex] as? MenuButtonsDelegate
+        }
         
         self.navigationController?.pushViewController(menuVC, animated: true)
     }


### PR DESCRIPTION
Addresses #17. Look Ahead was missing a delegate assignment when the info button was pressed so that the appropriate delegate method wasn't called to reload the favorites data in the original VC.
