### PR TITLE
Gonzalo/awkward cell popup

### DIFF
--- a/Eatery.xcodeproj/project.pbxproj
+++ b/Eatery.xcodeproj/project.pbxproj
@@ -66,7 +66,7 @@
 		C2A5E36B231CB6B10061E737 /* GoogleService-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = C2A5E36A231CB6B10061E737 /* GoogleService-Info.plist */; };
 		CE1B2E46224BFFF1005014AE /* CampusEateryMealTableViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = E93CD41A1BE67DB000089CE5 /* CampusEateryMealTableViewController.swift */; };
 		CE9C1FE1226431630062C398 /* EateriesViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE9C1FE0226431630062C398 /* EateriesViewController.swift */; };
-		D10246301C7A320C000D5CD8 /* (null) in Sources */ = {isa = PBXBuildFile; };
+		D10246301C7A320C000D5CD8 /* BuildFile in Sources */ = {isa = PBXBuildFile; };
 		D1EE777A1C702469001823D8 /* String+Manipulation.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1EE77791C702469001823D8 /* String+Manipulation.swift */; };
 		D930FBD8218BC00200B0B1CE /* BRBAccount.swift in Sources */ = {isa = PBXBuildFile; fileRef = D930FBD7218BC00200B0B1CE /* BRBAccount.swift */; };
 		D956DCAD2187B074001BB9B0 /* Keys.plist in Resources */ = {isa = PBXBuildFile; fileRef = D956DCAC2187B074001BB9B0 /* Keys.plist */; };
@@ -212,7 +212,7 @@
 		95F661F91E2E9F3D00591A54 /* LaunchScreen.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; path = LaunchScreen.storyboard; sourceTree = "<group>"; };
 		977293368558D040AFA7B199 /* Pods-Eatery Watch App.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Eatery Watch App.debug.xcconfig"; path = "Pods/Target Support Files/Pods-Eatery Watch App/Pods-Eatery Watch App.debug.xcconfig"; sourceTree = "<group>"; };
 		9BE935BDA323618D9A779B07 /* Pods-Eatery Watch App Extension.external beta.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Eatery Watch App Extension.external beta.xcconfig"; path = "Pods/Target Support Files/Pods-Eatery Watch App Extension/Pods-Eatery Watch App Extension.external beta.xcconfig"; sourceTree = "<group>"; };
-		BA0F42CF72757B43C3DF64BE /* Pods/Target Support Files/Pods-Eatery/Pods-Eatery.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods/Target Support Files/Pods-Eatery/Pods-Eatery.debug.xcconfig"; sourceTree = "<group>"; };
+		BA0F42CF72757B43C3DF64BE /* Pods-Eatery.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods/Target Support Files/Pods-Eatery/Pods-Eatery.debug.xcconfig"; sourceTree = "<group>"; };
 		C007CABF19E1BEAC00E3BD46 /* Eatery.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Eatery.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		C0497AF11B64AA1800AC1C6C /* UIColor+ColorScheme.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UIColor+ColorScheme.swift"; sourceTree = "<group>"; };
 		C0497AF51B64AA1800AC1C6C /* TimeFactory.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TimeFactory.swift; sourceTree = "<group>"; };
@@ -565,7 +565,7 @@
 		F71534A35C24A6E72160950C /* Pods */ = {
 			isa = PBXGroup;
 			children = (
-				BA0F42CF72757B43C3DF64BE /* Pods/Target Support Files/Pods-Eatery/Pods-Eatery.debug.xcconfig */,
+				BA0F42CF72757B43C3DF64BE /* Pods-Eatery.debug.xcconfig */,
 				561CC64F0A1AF41712E60CD0 /* Pods-Eatery.external beta.xcconfig */,
 				94AE18508AA0B5D148EEA361 /* Pods-Eatery.internal beta.xcconfig */,
 				2EFE6B659BF68ECA9CE402B4 /* Pods-Eatery.app store.xcconfig */,
@@ -752,7 +752,7 @@
 			files = (
 			);
 			inputPaths = (
-				"${PODS_ROOT}/Target Support Files/Pods-Eatery/Pods-Eatery-frameworks.sh",
+				"${SRCROOT}/Pods/Target Support Files/Pods-Eatery/Pods-Eatery-frameworks.sh",
 				"${BUILT_PRODUCTS_DIR}/ARCL/ARCL.framework",
 				"${BUILT_PRODUCTS_DIR}/Apollo/Apollo.framework",
 				"${BUILT_PRODUCTS_DIR}/FLEX/FLEX.framework",
@@ -779,7 +779,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-Eatery/Pods-Eatery-frameworks.sh\"\n";
+			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-Eatery/Pods-Eatery-frameworks.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
 		5D854A8521AF85A00067F745 /* [Apollo] Build Apollo */ = {
@@ -820,7 +820,7 @@
 			files = (
 			);
 			inputPaths = (
-				"${PODS_ROOT}/Target Support Files/Pods-Eatery Watch App Extension/Pods-Eatery Watch App Extension-frameworks.sh",
+				"${SRCROOT}/Pods/Target Support Files/Pods-Eatery Watch App Extension/Pods-Eatery Watch App Extension-frameworks.sh",
 				"${BUILT_PRODUCTS_DIR}/SwiftyJSON-watchOS/SwiftyJSON.framework",
 				"${BUILT_PRODUCTS_DIR}/Alamofire/Alamofire.framework",
 				"${BUILT_PRODUCTS_DIR}/DiningStack/DiningStack.framework",
@@ -833,7 +833,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-Eatery Watch App Extension/Pods-Eatery Watch App Extension-frameworks.sh\"\n";
+			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-Eatery Watch App Extension/Pods-Eatery Watch App Extension-frameworks.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
 		C97C4407B7162088D11A16B3 /* [CP] Check Pods Manifest.lock */ = {
@@ -916,7 +916,7 @@
 				60FF4E1C1CBEE03E0051FD01 /* MapViewController.swift in Sources */,
 				D956DCC12187B94E001BB9B0 /* Event.swift in Sources */,
 				6502AF871DCFB9ED00390EAA /* FilterBar.swift in Sources */,
-				D10246301C7A320C000D5CD8 /* (null) in Sources */,
+				D10246301C7A320C000D5CD8 /* BuildFile in Sources */,
 				5D0CC8E0223A949300526480 /* CampusEateriesViewController.swift in Sources */,
 				C26C57A0219642BC000E7FC9 /* EateryTabBarController.swift in Sources */,
 				5D218C4021FBE39700327516 /* EateryCollectionViewCell.swift in Sources */,
@@ -1041,7 +1041,7 @@
 		};
 		C007CADF19E1BEAC00E3BD46 /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = BA0F42CF72757B43C3DF64BE /* Pods/Target Support Files/Pods-Eatery/Pods-Eatery.debug.xcconfig */;
+			baseConfigurationReference = BA0F42CF72757B43C3DF64BE /* Pods-Eatery.debug.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				BUNDLE_SUFFIX = "-debug";

--- a/Eatery/Controllers/Eateries/PillViewController.swift
+++ b/Eatery/Controllers/Eateries/PillViewController.swift
@@ -101,6 +101,8 @@ class PillViewController: UIViewController {
     }
 
     func setShowPill(_ showPill: Bool, animated: Bool) {
+        // Prevents newly created cells from sharing the pill animation
+        view.layoutIfNeeded()
         let animation = UIViewPropertyAnimator(duration: 0.5, curve: .easeOut) {
             self.isShowingPill = showPill
             self.view.layoutIfNeeded()


### PR DESCRIPTION
Issue #204 

I went back to William's older commits to find where the bug began and eventually narrowed down the issue to starting within the scrollDidStart function and then to the setUpPill function's use of UIViewPropertyAnimator. Swiping too fast, upon opening the app, would cause cells to instantiate when the pill was playing its animation, causing the cells to share the animation. Using layoutIfNeeded() before the animation begins fixes this issue.

Before:
![ezgif com-resize (1)](https://user-images.githubusercontent.com/21962778/64294922-fad92400-cf3d-11e9-8b65-b64c1ea00eee.gif)


After:
![ezgif com-resize](https://user-images.githubusercontent.com/21962778/64294906-f14fbc00-cf3d-11e9-9f3a-86891c504c3a.gif)


