### PR TITLE
Add navigation bar and title to parallax view controller

### DIFF
--- a/Eatery.xcodeproj/project.pbxproj
+++ b/Eatery.xcodeproj/project.pbxproj
@@ -28,6 +28,7 @@
 		5D77412E2332E08400E9E699 /* ImageParallaxScrollViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5D77412D2332E08400E9E699 /* ImageParallaxScrollViewController.swift */; };
 		5D7A4C4F225BCEE6008242C4 /* CollegetownEateriesViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5D7A4C4E225BCEE6008242C4 /* CollegetownEateriesViewController.swift */; };
 		5D856458222A2D4E003A712B /* Menu.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5D856457222A2D4E003A712B /* Menu.swift */; };
+		5D9A119223368F0B00F430A1 /* EateriesNavigationController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5D9A119123368F0B00F430A1 /* EateriesNavigationController.swift */; };
 		5DACA8F7225B78B0009B0A2F /* CollegetownEatery.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5DACA8F6225B78B0009B0A2F /* CollegetownEatery.swift */; };
 		5DC06B7A21FE36020043701A /* PaymentMethodsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5DC06B7921FE36020043701A /* PaymentMethodsView.swift */; };
 		5DC2D01922349CE800D2B0F5 /* collegetownEateries.graphql in Resources */ = {isa = PBXBuildFile; fileRef = 5DC2D01822349CE800D2B0F5 /* collegetownEateries.graphql */; };
@@ -169,6 +170,7 @@
 		5D77412D2332E08400E9E699 /* ImageParallaxScrollViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ImageParallaxScrollViewController.swift; sourceTree = "<group>"; };
 		5D7A4C4E225BCEE6008242C4 /* CollegetownEateriesViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CollegetownEateriesViewController.swift; sourceTree = "<group>"; };
 		5D856457222A2D4E003A712B /* Menu.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Menu.swift; sourceTree = "<group>"; };
+		5D9A119123368F0B00F430A1 /* EateriesNavigationController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = EateriesNavigationController.swift; sourceTree = "<group>"; };
 		5DACA8F6225B78B0009B0A2F /* CollegetownEatery.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CollegetownEatery.swift; sourceTree = "<group>"; };
 		5DC06B7921FE36020043701A /* PaymentMethodsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaymentMethodsView.swift; sourceTree = "<group>"; };
 		5DC2D01822349CE800D2B0F5 /* collegetownEateries.graphql */ = {isa = PBXFileReference; lastKnownFileType = text; path = collegetownEateries.graphql; sourceTree = "<group>"; };
@@ -282,6 +284,7 @@
 			isa = PBXGroup;
 			children = (
 				5D77412D2332E08400E9E699 /* ImageParallaxScrollViewController.swift */,
+				5D9A119123368F0B00F430A1 /* EateriesNavigationController.swift */,
 				6560D4411F51F373009E7CEF /* Eateries */,
 				6560D4421F51F37A009E7CEF /* Lookahead */,
 				9584FE531CDD6C40001A3AB5 /* BRB */,
@@ -921,6 +924,7 @@
 				D956DCC12187B94E001BB9B0 /* Event.swift in Sources */,
 				6502AF871DCFB9ED00390EAA /* FilterBar.swift in Sources */,
 				D10246301C7A320C000D5CD8 /* (null) in Sources */,
+				5D9A119223368F0B00F430A1 /* EateriesNavigationController.swift in Sources */,
 				5D0CC8E0223A949300526480 /* CampusEateriesViewController.swift in Sources */,
 				C26C57A0219642BC000E7FC9 /* EateryTabBarController.swift in Sources */,
 				5D218C4021FBE39700327516 /* EateryCollectionViewCell.swift in Sources */,

--- a/Eatery/Controllers/EateriesNavigationController.swift
+++ b/Eatery/Controllers/EateriesNavigationController.swift
@@ -1,0 +1,30 @@
+//
+//  EateriesNavigationController.swift
+//  ScrollImageView
+//
+//  Created by William Ma on 9/21/19.
+//  Copyright © 2019 William Ma. All rights reserved.
+//
+
+import UIKit
+
+class EateriesNavigationController: UINavigationController {
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+
+        delegate = self
+        // allow swipe back gesture even if navigation bar is hidden
+        interactivePopGestureRecognizer?.delegate = nil
+    }
+
+}
+
+extension EateriesNavigationController: UINavigationControllerDelegate {
+
+    func navigationController(_ navigationController: UINavigationController, willShow viewController: UIViewController, animated: Bool) {
+        let isParallax = viewController is ImageParallaxScrollViewController
+        setNavigationBarHidden(isParallax, animated: true)
+    }
+
+}

--- a/Eatery/Controllers/ImageParallaxScrollViewController.swift
+++ b/Eatery/Controllers/ImageParallaxScrollViewController.swift
@@ -10,14 +10,34 @@ import Kingfisher
 import SnapKit
 import UIKit
 
+// MARK: - Image Parallalax Scroll View Controller
+
 /**
  Manage a scroll view and an image view with a parallax effect.
  */
 class ImageParallaxScrollViewController: UIViewController {
 
+    private let navigationBar = UINavigationBar()
+    var backButtonTitle: String? {
+        didSet {
+            reloadNavigationBarItems()
+        }
+    }
+    override var preferredStatusBarStyle: UIStatusBarStyle {
+        return .lightContent
+    }
+
     private let scrollView = UIScrollView()
     private let imageView = UIImageView()
-    
+
+    private let titleLabel = UILabel()
+    override var title: String? {
+        didSet {
+            titleLabel.text = title
+        }
+    }
+
+    let accessoryView = UIView()
     let contentView = UIView()
 
     override func viewDidLoad() {
@@ -30,9 +50,7 @@ class ImageParallaxScrollViewController: UIViewController {
         scrollView.delaysContentTouches = false
         view.addSubview(scrollView)
         scrollView.snp.makeConstraints { make in
-            make.top.equalTo(topLayoutGuide.snp.bottom)
-            make.bottom.equalTo(bottomLayoutGuide.snp.top)
-            make.leading.trailing.equalToSuperview()
+            make.edges.equalToSuperview()
         }
 
         imageView.contentMode = .scaleAspectFill
@@ -42,16 +60,64 @@ class ImageParallaxScrollViewController: UIViewController {
             make.top.leading.trailing.width.equalToSuperview()
         }
 
+        navigationBar.tintColor = .white
+        navigationBar.setBackgroundImage(UIImage(), for: .default)
+        navigationBar.barTintColor = .blue
+        navigationBar.shadowImage = UIImage()
+        navigationBar.delegate = self
+        scrollView.addSubview(navigationBar)
+        navigationBar.snp.makeConstraints { make in
+            make.top.equalToSuperview()
+            make.leading.trailing.equalToSuperview()
+        }
+
+        let gradientView = GradientView(frame: .zero)
+        gradientView.alpha = 0.5
+        scrollView.addSubview(gradientView)
+        gradientView.snp.makeConstraints { make in
+            make.leading.trailing.equalToSuperview()
+            make.bottom.equalTo(imageView)
+            make.height.equalTo(imageView).multipliedBy(2.0 / 3.0)
+        }
+
+        titleLabel.isOpaque = false
+        titleLabel.font = .boldSystemFont(ofSize: 34)
+        titleLabel.numberOfLines = 2
+        titleLabel.textColor = .white
+        titleLabel.setContentCompressionResistancePriority(UILayoutPriority(rawValue: 100), for: .horizontal)
+        scrollView.addSubview(titleLabel)
+        titleLabel.snp.makeConstraints { make in
+            make.leading.equalToSuperview().inset(16)
+            make.bottom.equalTo(imageView.snp.bottom).inset(16)
+        }
+
+        scrollView.addSubview(accessoryView)
+        accessoryView.snp.makeConstraints { make in
+            make.leading.equalTo(titleLabel.snp.trailing).offset(16)
+            make.width.equalTo(0).priority(.low) // compress the view if its not needed
+            make.trailing.equalToSuperview()
+            make.bottom.equalTo(imageView.snp.bottom).inset(16)
+        }
+
         contentView.backgroundColor = .green
         scrollView.addSubview(contentView)
         contentView.snp.makeConstraints { make in
             make.top.equalTo(imageView.snp.bottom)
             make.leading.trailing.bottom.equalToSuperview()
         }
+
+        reloadNavigationBarItems()
     }
 
     func loadImage(from url: URL) {
         imageView.kf.setImage(with: url)
+    }
+
+    private func reloadNavigationBarItems() {
+        navigationBar.items = [
+            UINavigationItem(title: backButtonTitle ?? ""),
+            UINavigationItem(title: "")
+        ]
     }
 
 }
@@ -66,12 +132,50 @@ extension ImageParallaxScrollViewController: UIScrollViewDelegate {
                 make.height.equalTo(view).dividedBy(3).offset(-scrollView.contentOffset.y)
             }
         } else {
-            imageView.transform = CGAffineTransform(translationX: 0.0, y: scrollView.contentOffset.y / 3)
+            imageView.transform = CGAffineTransform(translationX: 0, y: scrollView.contentOffset.y / 3)
             imageView.snp.updateConstraints { make in
                 make.top.equalToSuperview()
                 make.height.equalTo(view).dividedBy(3)
             }
         }
+
+        let adjustedOffset = scrollView.contentOffset.y + view.layoutMargins.top
+        if adjustedOffset < 0 {
+            navigationBar.transform = CGAffineTransform(translationX: 0, y: 2 / 3 * adjustedOffset)
+        } else {
+            navigationBar.transform = .identity
+        }
+    }
+
+}
+
+extension ImageParallaxScrollViewController: UINavigationBarDelegate {
+
+    func navigationBar(_ navigationBar: UINavigationBar, shouldPop item: UINavigationItem) -> Bool {
+        navigationController?.popViewController(animated: true)
+        return false
+    }
+
+}
+
+// MARK: - Gradient View
+
+private class GradientView: UIView {
+
+    override class var layerClass: AnyClass {
+        return CAGradientLayer.self
+    }
+
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+
+        if let gradientLayer = layer as? CAGradientLayer {
+            gradientLayer.colors = [UIColor.clear.cgColor, UIColor.black.cgColor]
+        }
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
     }
 
 }


### PR DESCRIPTION
Issue: #216 

Adds a bunch of enhancements to the parallax view controller: 
* Back button
* Title Label + Gradient
* Accessory View - This can be customized to whatever we want. I wanted to make the `ImageParallaxScrollViewController` not specific to Eatery. In both `MenuViewController`s, ~this will be replaced by the payment view.~ we will add the payment view to the accessory view. For the GIF below I have added a `UIButton` to demonstrate this.

After this PR, I plan to convert both Menu View Controllers to use `ImageParallaxScrollViewController`.

![out](https://user-images.githubusercontent.com/1882991/65376777-d84f4680-dc71-11e9-99bc-2934c8d23722.gif)
