### PR TITLE
Tabbed Page View Controller Refactor

### DIFF
--- a/Eatery.xcodeproj/project.pbxproj
+++ b/Eatery.xcodeproj/project.pbxproj
@@ -30,6 +30,8 @@
 		5D7A4C4F225BCEE6008242C4 /* CollegetownEateriesViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5D7A4C4E225BCEE6008242C4 /* CollegetownEateriesViewController.swift */; };
 		5D856458222A2D4E003A712B /* Menu.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5D856457222A2D4E003A712B /* Menu.swift */; };
 		5D9A119223368F0B00F430A1 /* EateryNavigationController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5D9A119123368F0B00F430A1 /* EateryNavigationController.swift */; };
+		5DAC0014233C0B37009FCCB0 /* CampusEateryMenuViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = E93CD4161BE67AC400089CE5 /* CampusEateryMenuViewController.swift */; };
+		5DAC0016233C1331009FCCB0 /* TabbedPageViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5DAC0015233C1331009FCCB0 /* TabbedPageViewController.swift */; };
 		5DACA8F7225B78B0009B0A2F /* CollegetownEatery.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5DACA8F6225B78B0009B0A2F /* CollegetownEatery.swift */; };
 		5DC06B7A21FE36020043701A /* PaymentMethodsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5DC06B7921FE36020043701A /* PaymentMethodsView.swift */; };
 		5DC2D01922349CE800D2B0F5 /* collegetownEateries.graphql in Resources */ = {isa = PBXBuildFile; fileRef = 5DC2D01822349CE800D2B0F5 /* collegetownEateries.graphql */; };
@@ -95,8 +97,6 @@
 		D971431D219A7F3D00E2EE05 /* TimeFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = D971431C219A7F3D00E2EE05 /* TimeFactory.swift */; };
 		D9714321219B953800E2EE05 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 659B216F1C70796600F3B138 /* Assets.xcassets */; };
 		D9714322219B953D00E2EE05 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 659B21831C70796600F3B138 /* Assets.xcassets */; };
-		E93CD4171BE67AC400089CE5 /* CampusEateryMenuViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = E93CD4161BE67AC400089CE5 /* CampusEateryMenuViewController.swift */; };
-		E93CD4191BE67C2300089CE5 /* TabbedPageViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = E93CD4181BE67C2300089CE5 /* TabbedPageViewController.swift */; };
 		E978DF851BEA8108000CD44F /* UnderlineTabBarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E978DF841BEA8108000CD44F /* UnderlineTabBarView.swift */; };
 		E9CFC0AA1C0E4A3000ED884A /* appendix.json in Resources */ = {isa = PBXBuildFile; fileRef = E9CFC0A81C0E4A3000ED884A /* appendix.json */; };
 /* End PBXBuildFile section */
@@ -175,6 +175,7 @@
 		5D7A4C4E225BCEE6008242C4 /* CollegetownEateriesViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CollegetownEateriesViewController.swift; sourceTree = "<group>"; };
 		5D856457222A2D4E003A712B /* Menu.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Menu.swift; sourceTree = "<group>"; };
 		5D9A119123368F0B00F430A1 /* EateryNavigationController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = EateryNavigationController.swift; sourceTree = "<group>"; };
+		5DAC0015233C1331009FCCB0 /* TabbedPageViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabbedPageViewController.swift; sourceTree = "<group>"; };
 		5DACA8F6225B78B0009B0A2F /* CollegetownEatery.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CollegetownEatery.swift; sourceTree = "<group>"; };
 		5DC06B7921FE36020043701A /* PaymentMethodsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaymentMethodsView.swift; sourceTree = "<group>"; };
 		5DC2D01822349CE800D2B0F5 /* collegetownEateries.graphql */ = {isa = PBXFileReference; lastKnownFileType = text; path = collegetownEateries.graphql; sourceTree = "<group>"; };
@@ -249,7 +250,6 @@
 		DFAF014CFABFD9D8E6AC7021 /* Pods-Eatery Watch App Extension.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Eatery Watch App Extension.debug.xcconfig"; path = "Pods/Target Support Files/Pods-Eatery Watch App Extension/Pods-Eatery Watch App Extension.debug.xcconfig"; sourceTree = "<group>"; };
 		E418A28B1A4C3F8781B50F84 /* Pods-Eatery Watch App Extension.app store.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Eatery Watch App Extension.app store.xcconfig"; path = "Pods/Target Support Files/Pods-Eatery Watch App Extension/Pods-Eatery Watch App Extension.app store.xcconfig"; sourceTree = "<group>"; };
 		E93CD4161BE67AC400089CE5 /* CampusEateryMenuViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CampusEateryMenuViewController.swift; sourceTree = "<group>"; };
-		E93CD4181BE67C2300089CE5 /* TabbedPageViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TabbedPageViewController.swift; sourceTree = "<group>"; };
 		E93CD41A1BE67DB000089CE5 /* CampusEateryMealTableViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CampusEateryMealTableViewController.swift; sourceTree = "<group>"; };
 		E978DF841BEA8108000CD44F /* UnderlineTabBarView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UnderlineTabBarView.swift; sourceTree = "<group>"; };
 		E99C63E91B6EDE12000A5886 /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
@@ -367,7 +367,7 @@
 				E93CD41A1BE67DB000089CE5 /* CampusEateryMealTableViewController.swift */,
 				5D7A4C4E225BCEE6008242C4 /* CollegetownEateriesViewController.swift */,
 				5DE1D426225E95CD008054F4 /* CollegetownEateriesMenuViewController.swift */,
-				E93CD4181BE67C2300089CE5 /* TabbedPageViewController.swift */,
+				5DAC0015233C1331009FCCB0 /* TabbedPageViewController.swift */,
 				60FF4E1B1CBEE03E0051FD01 /* MapViewController.swift */,
 			);
 			path = Eateries;
@@ -904,20 +904,20 @@
 				5D218C4821FC136E00327516 /* CLLocation+Distance.swift in Sources */,
 				5DEF1AA4222B328800855902 /* SwitchTableViewCell.swift in Sources */,
 				5D2790362336BC1400AA513B /* UINavigationBarAppearance+Eatery.swift in Sources */,
+				5DAC0014233C0B37009FCCB0 /* CampusEateryMenuViewController.swift in Sources */,
 				65E93179206C186B00547D14 /* Keys.swift in Sources */,
 				D930FBD8218BC00200B0B1CE /* BRBAccount.swift in Sources */,
 				874D83702336751D00E26728 /* EventPayload.swift in Sources */,
-				E93CD4171BE67AC400089CE5 /* CampusEateryMenuViewController.swift in Sources */,
 				5D4451A0231D51FE0035164F /* BRBLoginErrorView.swift in Sources */,
 				5DD8A8962315843900ED25FD /* EateriesCollectionViewGridLayout.swift in Sources */,
 				5D7A4C4F225BCEE6008242C4 /* CollegetownEateriesViewController.swift in Sources */,
-				E93CD4191BE67C2300089CE5 /* TabbedPageViewController.swift in Sources */,
 				5D218C3E21FBE39700327516 /* LookAheadHeaderView.swift in Sources */,
 				5D218C3D21FBE39700327516 /* FilterDateView.swift in Sources */,
 				5DF17733231C4BA200194D14 /* BRBViewController.swift in Sources */,
 				5D218C4321FBE39700327516 /* EateriesCollectionViewHeaderView.swift in Sources */,
 				D956DCB42187B4B1001BB9B0 /* NetworkManager.swift in Sources */,
 				5DF1772D231C46DA00194D14 /* BRBConnectionHandler.swift in Sources */,
+				5DAC0016233C1331009FCCB0 /* TabbedPageViewController.swift in Sources */,
 				5D6BF06B22126D1700AA36CD /* LookAheadViewController.swift in Sources */,
 				5DF17737231C5CAE00194D14 /* BRBPrivacyStatementViewController.swift in Sources */,
 				9584FE521CDD6C3B001A3AB5 /* KeychainItemWrapper.swift in Sources */,

--- a/Eatery.xcodeproj/xcshareddata/xcschemes/Eatery.xcscheme
+++ b/Eatery.xcodeproj/xcshareddata/xcschemes/Eatery.xcscheme
@@ -27,8 +27,6 @@
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       shouldUseLaunchSchemeArgsEnv = "YES">
-      <Testables>
-      </Testables>
       <MacroExpansion>
          <BuildableReference
             BuildableIdentifier = "primary"
@@ -38,8 +36,8 @@
             ReferencedContainer = "container:Eatery.xcodeproj">
          </BuildableReference>
       </MacroExpansion>
-      <AdditionalOptions>
-      </AdditionalOptions>
+      <Testables>
+      </Testables>
    </TestAction>
    <LaunchAction
       buildConfiguration = "Debug"
@@ -63,12 +61,10 @@
       </BuildableProductRunnable>
       <CommandLineArguments>
          <CommandLineArgument
-            argument = "-FIRAnalyticsDebugEnabled"
+            argument = "-FIRDebugDisabled"
             isEnabled = "YES">
          </CommandLineArgument>
       </CommandLineArguments>
-      <AdditionalOptions>
-      </AdditionalOptions>
    </LaunchAction>
    <ProfileAction
       buildConfiguration = "Debug"

--- a/Eatery/Controllers/Eateries/CampusEateryMealTableViewController.swift
+++ b/Eatery/Controllers/Eateries/CampusEateryMealTableViewController.swift
@@ -2,20 +2,21 @@ import UIKit
 
 class CampusEateryMealTableViewController: UITableViewController {
 
-    var meal: String!
+    let meal: String
+    let eatery: CampusEatery
+    let date: Date
 
-    var eatery: CampusEatery! {
-        didSet {
-            recomputeMenu()
-        }
-    }
-    var event: Event? {
-        didSet {
-            recomputeMenu()
-        }
-    }
+    let event: Event?
 
-    private func recomputeMenu() {
+    private let menu: Menu?
+
+    init(eatery: CampusEatery, meal: String, date: Date) {
+        self.eatery = eatery
+        self.meal = meal
+        self.date = date
+
+        self.event = eatery.eventsByName(onDayOf: date)[meal]
+
         if let eventMenu = event?.menu, !eventMenu.data.isEmpty {
             menu = eventMenu
         } else if eatery.diningMenu != nil, eatery.eateryType != .dining {
@@ -25,21 +26,13 @@ class CampusEateryMealTableViewController: UITableViewController {
             // don't know the menu
             menu = nil
         }
+
+        super.init(nibName: nil, bundle: nil)
     }
 
-    private var menu: Menu? {
-        didSet {
-            if let menu = menu, menu.data.count == 1, eatery.eateryType != .dining {
-                topSeparator.isHidden = false
-                tableView.separatorStyle = .singleLine
-            } else {
-                topSeparator.isHidden = true
-                tableView.separatorStyle = .none
-            }
-        }
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
     }
-
-    private let topSeparator = UIView()
 
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -57,11 +50,20 @@ class CampusEateryMealTableViewController: UITableViewController {
 
         tableView.isScrollEnabled = false
 
+        let topSeparator = UIView()
         topSeparator.frame = CGRect(x: 0, y: 0, width: view.frame.width, height: 1)
         topSeparator.backgroundColor = .inactive
         tableView.tableHeaderView = topSeparator
 
         tableView.tableFooterView = UIView(frame: CGRect(x: 0, y: 0, width: view.frame.width, height: 60))
+
+        if let menu = menu, menu.data.count == 1, eatery.eateryType != .dining {
+            topSeparator.isHidden = false
+            tableView.separatorStyle = .singleLine
+        } else {
+            topSeparator.isHidden = true
+            tableView.separatorStyle = .none
+        }
     }
 
     override func viewDidAppear(_ animated: Bool) {

--- a/Eatery/Controllers/Eateries/CampusEateryMenuViewController.swift
+++ b/Eatery/Controllers/Eateries/CampusEateryMenuViewController.swift
@@ -10,7 +10,7 @@ private let TitleDateFormatter: DateFormatter = {
     return formatter
 }()
 
-class CampusEateryMenuViewController: UIViewController, UIScrollViewDelegate, MenuButtonsDelegate, TabbedPageViewControllerScrollDelegate {
+class CampusEateryMenuViewController: UIViewController, UIScrollViewDelegate, MenuButtonsDelegate {
 
     var eatery: CampusEatery
     var outerScrollView: UIScrollView!
@@ -21,10 +21,6 @@ class CampusEateryMenuViewController: UIViewController, UIScrollViewDelegate, Me
     var selectedMeal: String?
     var userLocation: CLLocation?
     var navigationTitleView: NavigationTitleView!
-
-    var pageViewControllerHeight: CGFloat {
-        return pageViewController.pluckCurrentScrollView().contentSize.height + (pageViewController.tabBar?.frame.height ?? 0.0)
-    }
     
     init(eatery: CampusEatery, delegate: MenuButtonsDelegate?, date: Date = Date(), meal: String? = nil, userLocation: CLLocation? = nil) {
         self.eatery = eatery
@@ -63,9 +59,7 @@ class CampusEateryMenuViewController: UIViewController, UIScrollViewDelegate, Me
         navigationTitleView.dateLabel.text = dateTitle
         navigationItem.titleView = navigationTitleView
         
-        if #available(iOS 11.0, *) {
-            navigationItem.largeTitleDisplayMode = .never
-        }
+        navigationItem.largeTitleDisplayMode = .never
 
         setupScrollView()
     }
@@ -255,10 +249,8 @@ class CampusEateryMenuViewController: UIViewController, UIScrollViewDelegate, Me
         }
         
         // PageViewController
-        pageViewController = TabbedPageViewController()
-        pageViewController.viewControllers = mealViewControllers
-        pageViewController.scrollDelegate = self
-
+        pageViewController = TabbedPageViewController(viewControllers: mealViewControllers)
+        pageViewController.delegate = self
         addChildViewController(pageViewController)
         contentContainer.addSubview(pageViewController.view)
         pageViewController.didMove(toParentViewController: self)
@@ -266,7 +258,6 @@ class CampusEateryMenuViewController: UIViewController, UIScrollViewDelegate, Me
         pageViewController.view.snp.makeConstraints { make in
             make.top.equalTo(menuLabel.snp.bottom)
             make.leading.trailing.bottom.equalToSuperview()
-            make.height.equalTo(pageViewControllerHeight)
         }
 
         contentView.addSubview(contentContainer)
@@ -342,12 +333,6 @@ class CampusEateryMenuViewController: UIViewController, UIScrollViewDelegate, Me
         }
     }
     
-    func scrollViewDidChange() {
-        pageViewController.view.snp.updateConstraints { make in
-            make.height.equalTo(pageViewControllerHeight)
-        }
-    }
-    
     // MARK: -
     // MARK: MenuButtonsDelegate
     
@@ -390,21 +375,21 @@ class CampusEateryMenuViewController: UIViewController, UIScrollViewDelegate, Me
     // MARK: Scroll To Proper Time
     
     func scrollToCurrentTimeOpening(_ date: Date) {
-        guard let currentEvent = eatery.activeEvent(atExactly: date) else { return }
-        guard let mealViewControllers = pageViewController.viewControllers as? [CampusEateryMealTableViewController],
-            mealViewControllers.count > 1 else { return }
-        
-        let desiredMealVC: (CampusEateryMealTableViewController) -> Bool = {
-            if currentEvent.desc == "Lite Lunch" {
-                return $0.meal == "Lunch"
-            } else {
-                let mealName = self.selectedMeal ?? currentEvent.desc
-                return $0.event?.desc == mealName
-            }
+        guard let currentEvent = eatery.activeEvent(atExactly: date) else {
+            return
         }
-        
-        if let currentVC = mealViewControllers.filter(desiredMealVC).first {
-            pageViewController.scrollToViewController(currentVC)
+
+        guard let mealViewControllers = pageViewController.viewControllers as? [CampusEateryMealTableViewController],
+            mealViewControllers.count > 1 else {
+                return
+        }
+
+        for (index, viewController) in mealViewControllers.enumerated() {
+            if currentEvent.desc == "Lite Lunch", viewController.meal == "Lunch" {
+                pageViewController.currentViewControllerIndex = index
+            } else if viewController.event?.desc == selectedMeal ?? currentEvent.desc {
+                pageViewController.currentViewControllerIndex = index
+            }
         }
     }
 }
@@ -429,5 +414,27 @@ extension CampusEateryMenuViewController: MFMailComposeViewControllerDelegate {
     func mailComposeController(_ controller: MFMailComposeViewController, didFinishWith result: MFMailComposeResult, error: Error?) {
         controller.dismiss(animated: true, completion: nil)
     }
+}
+
+extension CampusEateryMenuViewController: TabbedPageViewControllerDelegate {
+
+    func tabbedPageViewController(_ tabbedPageViewController: TabbedPageViewController, titleForViewController viewController: UIViewController) -> String? {
+        guard let mealViewController = viewController as? CampusEateryMealTableViewController else {
+            return nil
+        }
+
+        return mealViewController.meal
+    }
+
+    func tabbedPageViewController(_ tabbedPageViewController: TabbedPageViewController,
+                                  heightOfContentForViewController viewController: UIViewController) -> CGFloat {
+        guard let mealViewController = viewController as? CampusEateryMealTableViewController else {
+            return 0
+        }
+
+        mealViewController.view.layoutIfNeeded()
+        return mealViewController.tableView.contentSize.height
+    }
+
 }
 

--- a/Eatery/Controllers/Eateries/CampusEateryMenuViewController.swift
+++ b/Eatery/Controllers/Eateries/CampusEateryMenuViewController.swift
@@ -240,10 +240,9 @@ class CampusEateryMenuViewController: UIViewController, UIScrollViewDelegate, Me
         }
         
         let mealViewControllers: [CampusEateryMealTableViewController] = meals.map {
-            let mealVC = CampusEateryMealTableViewController()
-            mealVC.eatery = eatery
-            mealVC.meal = $0
-            mealVC.event = eventsDict[$0]
+            let mealVC = CampusEateryMealTableViewController(eatery: eatery,
+                                                             meal: $0,
+                                                             date: displayedDate)
             mealVC.tableView.layoutIfNeeded()
             return mealVC
         }

--- a/Eatery/Controllers/Eateries/TabbedPageViewController.swift
+++ b/Eatery/Controllers/Eateries/TabbedPageViewController.swift
@@ -122,6 +122,9 @@ class TabbedPageViewController: UIViewController {
         pageViewControllerDidChangeViewController()
     }
 
+    /// Call this method when the page VC's children are modified.
+    /// This method updates the underline bar and adjusts the page view
+    /// controller's height. 
     private func pageViewControllerDidChangeViewController() {
         tabBar?.updateSelectedTabAppearance(currentViewControllerIndex ?? 0)
         adjustPageViewControllerHeight()

--- a/Eatery/Controllers/Eateries/TabbedPageViewController.swift
+++ b/Eatery/Controllers/Eateries/TabbedPageViewController.swift
@@ -8,8 +8,6 @@
 
 import UIKit
 
-// MARK: -
-
 protocol TabbedPageViewControllerDelegate: AnyObject {
 
     func tabbedPageViewController(_ tabbedPageViewController: TabbedPageViewController,
@@ -19,8 +17,6 @@ protocol TabbedPageViewControllerDelegate: AnyObject {
                                   heightOfContentForViewController viewController: UIViewController) -> CGFloat
 
 }
-
-// MARK: -
 
 class TabbedPageViewController: UIViewController {
 

--- a/Eatery/Views/Eateries/UnderlineTabBarView.swift
+++ b/Eatery/Views/Eateries/UnderlineTabBarView.swift
@@ -14,7 +14,7 @@ protocol TabBarDelegate: AnyObject {
 
 private let kCornerRadius: CGFloat = 12.0
 
-class UnderlineTabBarView: UIView, TabbedPageViewControllerDelegate {
+class UnderlineTabBarView: UIView {
     
     weak var delegate: TabBarDelegate?
 
@@ -86,10 +86,6 @@ class UnderlineTabBarView: UIView, TabbedPageViewControllerDelegate {
         let index = tabButtons.index(of: sender)!
         updateSelectedTabAppearance(index)
         delegate?.selectedTabDidChange(index)
-    }
-    
-    func selectedTabDidChange(_ newIndex: Int) {
-        updateSelectedTabAppearance(newIndex)
     }
     
     required init?(coder aDecoder: NSCoder) {


### PR DESCRIPTION
Issue: #216 

Some issues with the previous implementation of `TabbedPageViewController` (`TabbedPVC`)
1. It was closely coupled with `CampusEateryMealTVC` when it didn't need to be.
2. The `TabbedPVC` had two delegates which made the flow of information confusing. The "regular" delegate was used to update the `UnderlineTabBarView`. The "scroll" delegate was used to notify the `CampusEateryMenuVC` that the meal view controller had changed, and therefore the height of its content needed to be updated.
3. When the `CampusEateryMenuVC` was notified that the meal view controller had changed, it set constraints on the view of the `TabbedPVC`, which meant that additional constraints were being added to the `TabbedPVC` that it was not aware of.
4. The `TabbedPVC` would crash if it was given no view controllers. Although this is guarded against in the `CampusEateryMenuVC`, it would be better if the `TabbedPVC` could ensure itself that it could never access an out of bounds index.

How these issues were solved: 
1. Instead of accessing properties on the `CampusEateryMealTVC`, delegate that functionality out.
2. 
   * I removed the delegate used to update the `UnderlineTabBarView` and instead call methods on `UnderlineTabBarView` directly.
   * The purpose of the scroll delegate was to change the height of the page view controller. Have the page view controller ask its delegate for the height of a specific child and set constraints on itself.
3. Solving (2) also solved (3)
4. Add additional bounds checks. 

Some additional improvements: 
* The `CampusEateryMealTVC` had several implicitly unwrapped optionals that were set upon initialization. Instead, I used an initializer to remove the need for IUOs. 