### PR TITLE
Reload AccountTableView on Refresh

### DIFF
--- a/Eatery/Controllers/BRB/BRBViewController.swift
+++ b/Eatery/Controllers/BRB/BRBViewController.swift
@@ -106,7 +106,7 @@ class BRBViewController: UIViewController {
             loginViewController.view.isHidden = false
             
         case (.account, .account(let account)):
-            self.accountViewController?.view.removeFromSuperview()
+            accountViewController?.view.removeFromSuperview()
             let accountViewController = BRBAccountViewController(account: account)
             self.accountViewController = accountViewController
             self.accountViewController?.delegate = self

--- a/Eatery/Controllers/BRB/BRBViewController.swift
+++ b/Eatery/Controllers/BRB/BRBViewController.swift
@@ -105,7 +105,18 @@ class BRBViewController: UIViewController {
             
             loginViewController.view.isHidden = false
             
-        case (.account, .account), (.login, .login):
+        case (.account, .account(let account)):
+            self.accountViewController?.view.removeFromSuperview()
+            let accountViewController = BRBAccountViewController(account: account)
+            self.accountViewController = accountViewController
+            self.accountViewController?.delegate = self
+            addChildViewController(accountViewController)
+            view.insertSubview(accountViewController.view, at: 0)
+            accountViewController.view.snp.makeConstraints { make in
+                make.edges.equalToSuperview()
+            }
+            accountViewController.didMove(toParentViewController: self)
+        case (.login, .login):
             break
             
         }
@@ -175,6 +186,7 @@ extension BRBViewController: AboutTableViewControllerDelegate {
         setState(.login)
         navigationItem.title = "Account Info"
         accountManager.removeSavedLoginInfo()
+        accountManager.cancelRequest()
         accountManager.resetConnectionHandler()
         loggedIn = false
         activityIndicator.stopAnimating()


### PR DESCRIPTION
Fixed bug when user refreshes BRBViewController


## Overview
Before when the user refreshed the BRBViewController manually, the table would not update, but now it does.


## Changes Made

Added a case for when the state changes from a previous account (cached account) to the new account (queried account) and replaced the existing BRBAccountViewController.



## Test Coverage

Manual testing


