### PR TITLE
Fixes Apollo Build Phase Script & updates README with updated onboarding instructions

### DIFF
--- a/Eatery.xcodeproj/project.pbxproj
+++ b/Eatery.xcodeproj/project.pbxproj
@@ -1094,7 +1094,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "APOLLO_FRAMEWORK_PATH=\"$(eval find $FRAMEWORK_SEARCH_PATHS -name \\\"Apollo.framework\\\" -maxdepth 1)\"\n\nif [ -z \"$APOLLO_FRAMEWORK_PATH\" ]; then\necho \"error: Couldn't find Apollo.framework in FRAMEWORK_SEARCH_PATHS; make sure to add the framework to your project.\"\nexit 1\nfi\n\ncd \"${SRCROOT}/${TARGET_NAME}\"\n\"$APOLLO_FRAMEWORK_PATH\"/check-and-run-apollo-cli.sh codegen:generate --queries=\"$(find . -name '*.graphql')\" --schema=schema.json API.swift\n";
+			shellScript = "APOLLO_FRAMEWORK_PATH=\"$(eval find $FRAMEWORK_SEARCH_PATHS -name \\\"Apollo.framework\\\" -maxdepth 1)\"\n\nif [ -z \"$APOLLO_FRAMEWORK_PATH\" ]; then\necho \"error: Couldn't find Apollo.framework in FRAMEWORK_SEARCH_PATHS; make sure to add the framework to your project.\"\nexit 1\nfi\n\ncd \"${SRCROOT}/${TARGET_NAME}\"\n\"$APOLLO_FRAMEWORK_PATH\"/check-and-run-apollo-cli.sh codegen:generate --queries=\"$(find . -name '*.graphql')\" --schema=\"$SRCROOT\"/schema.json API.swift\n";
 		};
 		5D854A8521AF85A00067F745 /* [Apollo] Build Apollo */ = {
 			isa = PBXShellScriptBuildPhase;
@@ -1108,7 +1108,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "APOLLO_FRAMEWORK_PATH=\"$(eval find $FRAMEWORK_SEARCH_PATHS -name \\\"Apollo.framework\\\" -maxdepth 1)\"\n\nif [ -z \"$APOLLO_FRAMEWORK_PATH\" ]; then\necho \"error: Couldn't find Apollo.framework in FRAMEWORK_SEARCH_PATHS; make sure to add the framework to your project.\"\nexit 1\nfi\n\ncd \"${SRCROOT}/${TARGET_NAME}\"\n\"$APOLLO_FRAMEWORK_PATH\"/check-and-run-apollo-cli.sh codegen:generate --queries=\"$(find . -name '*.graphql')\" --schema=schema.json API.swift\n";
+			shellScript = "APOLLO_FRAMEWORK_PATH=\"$(eval find $FRAMEWORK_SEARCH_PATHS -name \\\"Apollo.framework\\\" -maxdepth 1)\"\n\nif [ -z \"$APOLLO_FRAMEWORK_PATH\" ]; then\necho \"error: Couldn't find Apollo.framework in FRAMEWORK_SEARCH_PATHS; make sure to add the framework to your project.\"\nexit 1\nfi\n\ncd \"${SRCROOT}/${TARGET_NAME}\"\n\"$APOLLO_FRAMEWORK_PATH\"/check-and-run-apollo-cli.sh codegen:generate --queries=\"$(find . -name '*.graphql')\" --schema=\"$SRCROOT\"/schema.json API.swift\n";
 		};
 		9DEA07504979C55F42669623 /* [CP] Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;

--- a/README.md
+++ b/README.md
@@ -18,7 +18,8 @@ We use [Firebase](https://firebase.google.com) for our user analytics. You will 
 
 We also use `GraphQL` to retrieve data from our backend server and use `Apollo` on the client side in order to help us do so. 
 
-To setup `Apollo`, you will have to first install it by running `npm install -g apollo@1.9` in the project directory.
-Next, You will have to retrieve a `schema.json` file by running: `apollo schema:download --endpoint={Backend_URL} schema.json` in the <strong>project directory</strong>.
+To setup `Apollo`, you will have to first install it by running `npm install -g apollo@1.9` in the project directory (make sure you specify version 1.9).
+
+You will also have to retrieve a `schema.json` file by running: `apollo schema:download --endpoint={Backend_URL} schema.json` in the <strong>project directory</strong>.
 
 Finally, open `Eatery.xcworkspace` and enjoy Eatery!

--- a/README.md
+++ b/README.md
@@ -14,24 +14,11 @@ We use [CocoaPods](http://cocoapods.org) for our dependency manager. This should
 To access the project, clone the project, and run `pod install` in the project directory.
 
 ### 2. Configuration
-We use [Fabric](https://fabric.io) and Crashlytics for our user analytics. To run the project without a Fabric account, comment out this line in `AppDelegate.swift`:
-```swift
-Crashlytics.start(withAPIKey: Keys.fabricAPIKey.value)
-```
+We use [Firebase](https://firebase.google.com) for our user analytics. You will have to retrieve a `GoogleService-Info.plist` from Firebase and then place it inside the `Eatery/` directory.
 
-Otherwise, to build the project, you need a `Secrets/Keys.plist` file in the project in order to use Fabric / Crashlytics:
-```xml
-<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
-<plist version="1.0">
-<dict>
-	<key>fabric-api-key</key>
-	<string>INSERT_API_KEY</string>
-	<key>fabric-build-secret</key>
-	<string>INSERT_BUILD_SECRET</string>
-</dict>
-</plist>
+We also use `GraphQL` to retrieve data from our backend server and use `Apollo` on the client side in order to help us do so. 
 
-```
+To setup `Apollo`, you will have to first install it by running `npm install -g apollo@1.9` in the project directory.
+Next, You will have to retrieve a `schema.json` file by running: `apollo schema:download --endpoint={Backend_URL} schema.json` in the <strong>project directory</strong>.
 
 Finally, open `Eatery.xcworkspace` and enjoy Eatery!


### PR DESCRIPTION
<!-- IF A SECTION IS NOT APPLICABLE TO YOU, PLEASE DELETE IT!! -->

<!-- Your title should be able to summarize what changes you've made in one sentence. For example: "Exclude staff from the check for follows". For stacked PRs, please indicate clearly in the title where in the stack you are. For example: "[Eatery Refactor][4/5] Converted all files to MVP model" -->



## Overview

<!-- Summarize your changes here. -->

I made changes to the `Apollo` build script phase to simplify setup of Apollo for new users and also updated the README with new onboarding instructions (some of the instructions were also outdated, i.e. we don't need `Keys.plist` anymore).

## Changes Made

<!-- Include details of what your changes actually are and how it is intended to work. -->
Currently both `Eatery` and `Eatery Watch App Extension` relies on `Apollo` which means that both of these two targets require an `schema.json` to generate their necessary `API.swift` files. The old Apollo Build Script phase checked for `schema.json` in the `$SRCROOT/$TARGET_NAME` directory which means that users would need the `schema.json` file in both the `Eatery` and `Eatery Watch App Extension` directories which is unnecessary because the `schema.json` files are the same anyways.

To fix this, I changed it so that when the Apollo build phase script is run, it just looks for `schema.json` inside `$SRCROOT/schema.json` which means users will just need to have the `schema.json` file downloaded inside the root project directory.


## Test Coverage

<!-- Describe how you tested this feature. Manual testing and/or unit testing. Please include repro steps and/or how to turn the feature on if applicable. -->

Ran the app and made sure it builds
