### PR TITLE
Integrates AppDevAnnouncements pod

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@ Secrets/
 Eatery/schema.json
 Eatery/API.swift
 Eatery/GoogleService-Info.plist
+Eatery/Supporting/Secrets.plist
 build/
 *.pbxuser
 !default.pbxuser

--- a/Eatery.xcodeproj/project.pbxproj
+++ b/Eatery.xcodeproj/project.pbxproj
@@ -113,6 +113,8 @@
 		C0497B161B64AA1800AC1C6C /* TimeFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0497AF51B64AA1800AC1C6C /* TimeFactory.swift */; };
 		C0497BAF1B64AA3800AC1C6C /* Images.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = C0497B581B64AA3800AC1C6C /* Images.xcassets */; };
 		C0F182FA1B674B1300063D77 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0F182F81B674B1300063D77 /* AppDelegate.swift */; };
+		C21D107D2400F535000A488B /* Secrets.swift in Sources */ = {isa = PBXBuildFile; fileRef = C21D107C2400F535000A488B /* Secrets.swift */; };
+		C21D107F2400FC53000A488B /* Secrets.plist in Resources */ = {isa = PBXBuildFile; fileRef = C21D107E2400FC53000A488B /* Secrets.plist */; };
 		C26C57A0219642BC000E7FC9 /* EateryTabBarController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C26C579F219642BC000E7FC9 /* EateryTabBarController.swift */; };
 		C82C9B83238D75C200DC18CF /* OnboardingPrivacyStatementViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C82C9B82238D75C200DC18CF /* OnboardingPrivacyStatementViewController.swift */; };
 		C82E5F032388E96400C881B2 /* OnboardingPageViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C82E5EFF2388E96400C881B2 /* OnboardingPageViewController.swift */; };
@@ -306,6 +308,8 @@
 		C0497AF51B64AA1800AC1C6C /* TimeFactory.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TimeFactory.swift; sourceTree = "<group>"; };
 		C0497B581B64AA3800AC1C6C /* Images.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Images.xcassets; sourceTree = "<group>"; };
 		C0F182F81B674B1300063D77 /* AppDelegate.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
+		C21D107C2400F535000A488B /* Secrets.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Secrets.swift; sourceTree = "<group>"; };
+		C21D107E2400FC53000A488B /* Secrets.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Secrets.plist; sourceTree = "<group>"; };
 		C26C579F219642BC000E7FC9 /* EateryTabBarController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EateryTabBarController.swift; sourceTree = "<group>"; };
 		C82C9B82238D75C200DC18CF /* OnboardingPrivacyStatementViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingPrivacyStatementViewController.swift; sourceTree = "<group>"; };
 		C82E5EFF2388E96400C881B2 /* OnboardingPageViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = OnboardingPageViewController.swift; sourceTree = "<group>"; };
@@ -712,6 +716,7 @@
 		C0497ACA1B64AA1800AC1C6C /* Eatery */ = {
 			isa = PBXGroup;
 			children = (
+				C21D10792400F48B000A488B /* Supporting */,
 				8724A0772349637E00D92EE3 /* GoogleService-Info.plist */,
 				D97142E6219A6B6F00E2EE05 /* API.swift */,
 				C0F182F81B674B1300063D77 /* AppDelegate.swift */,
@@ -779,6 +784,15 @@
 				95F661F91E2E9F3D00591A54 /* LaunchScreen.storyboard */,
 			);
 			path = Resources;
+			sourceTree = "<group>";
+		};
+		C21D10792400F48B000A488B /* Supporting */ = {
+			isa = PBXGroup;
+			children = (
+				C21D107E2400FC53000A488B /* Secrets.plist */,
+				C21D107C2400F535000A488B /* Secrets.swift */,
+			);
+			path = Supporting;
 			sourceTree = "<group>";
 		};
 		C83AEAAF237A476B00663C8D /* Onboarding */ = {
@@ -1002,6 +1016,7 @@
 				D956DCB12187B2BF001BB9B0 /* campusEateries.graphql in Resources */,
 				C0497BAF1B64AA3800AC1C6C /* Images.xcassets in Resources */,
 				8724A0782349637E00D92EE3 /* GoogleService-Info.plist in Resources */,
+				C21D107F2400FC53000A488B /* Secrets.plist in Resources */,
 				E9CFC0AA1C0E4A3000ED884A /* appendix.json in Resources */,
 				95F661FA1E2E9F3D00591A54 /* LaunchScreen.storyboard in Resources */,
 				5DC2D01922349CE800D2B0F5 /* collegetownEateries.graphql in Resources */,
@@ -1046,6 +1061,7 @@
 				"${PODS_ROOT}/Target Support Files/Pods-Eatery/Pods-Eatery-frameworks.sh",
 				"${BUILT_PRODUCTS_DIR}/ARCL/ARCL.framework",
 				"${BUILT_PRODUCTS_DIR}/Apollo-iOS/Apollo.framework",
+				"${BUILT_PRODUCTS_DIR}/AppDevAnnouncements/AppDevAnnouncements.framework",
 				"${BUILT_PRODUCTS_DIR}/BulletinBoard/BLTNBoard.framework",
 				"${BUILT_PRODUCTS_DIR}/CHIPageControl/CHIPageControl.framework",
 				"${BUILT_PRODUCTS_DIR}/FLEX/FLEX.framework",
@@ -1063,6 +1079,7 @@
 			outputPaths = (
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/ARCL.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/Apollo.framework",
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/AppDevAnnouncements.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/BLTNBoard.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/CHIPageControl.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/FLEX.framework",
@@ -1263,6 +1280,7 @@
 				87E712EE23416C3300085DB5 /* GivingDayViewController.swift in Sources */,
 				C89E17FB236E3FB300E89014 /* BRBAccountManager.swift in Sources */,
 				5D218C4021FBE39700327516 /* EateryCollectionViewCell.swift in Sources */,
+				C21D107D2400F535000A488B /* Secrets.swift in Sources */,
 				D956DCB92187B885001BB9B0 /* CampusEatery.swift in Sources */,
 				5DE1D42C225E95EB008054F4 /* RatingView.swift in Sources */,
 				5D218C3F21FBE39700327516 /* FilterEateriesView.swift in Sources */,

--- a/Eatery/Analytics/Analytics.swift
+++ b/Eatery/Analytics/Analytics.swift
@@ -129,3 +129,8 @@ struct CampusCafeCellPressPayload: Payload {
 struct CollegetownCellPressPayload: Payload {
     let eventName = "collegetown_eatery_press"
 }
+
+/// Log whenever an announcement is presented to the user
+struct AnnouncementPresentedPayload: Payload {
+    let eventName = "announcement_presented"
+}

--- a/Eatery/AppDelegate.swift
+++ b/Eatery/AppDelegate.swift
@@ -1,3 +1,4 @@
+import AppDevAnnouncements
 import Fabric
 import Firebase
 import Hero
@@ -18,6 +19,13 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         
         let URLCache = Foundation.URLCache(memoryCapacity: 4 * 1024 * 1024, diskCapacity: 20 * 1024 * 1024, diskPath: nil)
         Foundation.URLCache.shared = URLCache
+
+        AnnouncementNetworking.setupConfig(
+            scheme: Secrets.announcementsScheme,
+            host: Secrets.announcementsHost,
+            commonPath: Secrets.announcementsCommonPath,
+            announcementPath: Secrets.announcementsPath
+        )
 
         window = UIWindow()
         window?.backgroundColor = .white

--- a/Eatery/Controllers/Eateries/EateriesSharedViewController.swift
+++ b/Eatery/Controllers/Eateries/EateriesSharedViewController.swift
@@ -6,6 +6,7 @@
 //  Copyright © 2019 CUAppDev. All rights reserved.
 //
 
+import AppDevAnnouncements
 import CoreLocation
 import UIKit
 
@@ -50,6 +51,9 @@ class EateriesSharedViewController: UIViewController {
         setUpNavigationBar()
         setUpChildViewControllers()
         setUpPillView()
+
+        // Present announcement if there are any new ones to present
+        presentAnnouncement(completion: nil)
     }
 
     override func viewDidAppear(_ animated: Bool) {

--- a/Eatery/Controllers/Eateries/EateriesSharedViewController.swift
+++ b/Eatery/Controllers/Eateries/EateriesSharedViewController.swift
@@ -53,7 +53,11 @@ class EateriesSharedViewController: UIViewController {
         setUpPillView()
 
         // Present announcement if there are any new ones to present
-        presentAnnouncement(completion: nil)
+        presentAnnouncement { presented in
+            if presented {
+                AppDevAnalytics.shared.logFirebase(AnnouncementPresentedPayload())
+            }
+        }
     }
 
     override func viewDidAppear(_ animated: Bool) {

--- a/Eatery/Supporting/Secrets.swift
+++ b/Eatery/Supporting/Secrets.swift
@@ -1,0 +1,25 @@
+//
+//  Keys.swift
+//  Eatery
+//
+//  Created by Kevin Chan on 2/22/20.
+//  Copyright © 2020 CUAppDev. All rights reserved.
+//
+
+import Foundation
+
+struct Secrets {
+
+    static let announcementsCommonPath = Secrets.keyDict["announcements-common-path"] as! String
+    static let announcementsHost = Secrets.keyDict["announcements-host"] as! String
+    static let announcementsPath = Secrets.keyDict["announcements-path"] as! String
+    static let announcementsScheme = Secrets.keyDict["announcements-scheme"] as! String
+
+    private static let keyDict: NSDictionary = {
+        guard let path = Bundle.main.path(forResource: "Keys", ofType: "plist"),
+            let dict = NSDictionary(contentsOfFile: path) else { return [:] }
+        return dict
+    }()
+
+}
+

--- a/Eatery/Supporting/Secrets.swift
+++ b/Eatery/Supporting/Secrets.swift
@@ -10,13 +10,13 @@ import Foundation
 
 struct Secrets {
 
-    static let announcementsCommonPath = Secrets.keyDict["announcements-common-path"] as! String
-    static let announcementsHost = Secrets.keyDict["announcements-host"] as! String
-    static let announcementsPath = Secrets.keyDict["announcements-path"] as! String
-    static let announcementsScheme = Secrets.keyDict["announcements-scheme"] as! String
+    static let announcementsCommonPath = Secrets.secretDict["announcements-common-path"] as! String
+    static let announcementsHost = Secrets.secretDict["announcements-host"] as! String
+    static let announcementsPath = Secrets.secretDict["announcements-path"] as! String
+    static let announcementsScheme = Secrets.secretDict["announcements-scheme"] as! String
 
-    private static let keyDict: NSDictionary = {
-        guard let path = Bundle.main.path(forResource: "Keys", ofType: "plist"),
+    private static let secretDict: NSDictionary = {
+        guard let path = Bundle.main.path(forResource: "Secrets", ofType: "plist"),
             let dict = NSDictionary(contentsOfFile: path) else { return [:] }
         return dict
     }()

--- a/Podfile
+++ b/Podfile
@@ -11,8 +11,10 @@ target 'Eatery' do
     platform :ios, '11.0'
     shared_pods
 
+    pod 'AppDevAnnouncements', :git => 'https://github.com/cuappdev/appdev-announcements.git'
     pod 'ARCL'
     pod 'BulletinBoard'
+    pod 'CHIPageControl/Jaloro'
     pod 'FLEX', '~> 2.0', :configurations => ['Debug']
     pod 'Fabric'
     pod 'Firebase/Analytics'
@@ -20,7 +22,6 @@ target 'Eatery' do
     pod 'Kingfisher'
     pod 'NVActivityIndicatorView'
     pod 'SnapKit'
-    pod 'CHIPageControl/Jaloro'
     pod 'lottie-ios'
 end
 

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -2,6 +2,7 @@ PODS:
   - Apollo (0.9.5):
     - Apollo/Core (= 0.9.5)
   - Apollo/Core (0.9.5)
+  - AppDevAnnouncements (0.0.1)
   - ARCL (1.0.4)
   - BulletinBoard (4.1.0)
   - CHIPageControl/Jaloro (0.2)
@@ -73,6 +74,7 @@ PODS:
 
 DEPENDENCIES:
   - Apollo (from `https://github.com/apollographql/apollo-ios.git`)
+  - AppDevAnnouncements (from `https://github.com/cuappdev/appdev-announcements.git`)
   - ARCL
   - BulletinBoard
   - CHIPageControl/Jaloro
@@ -113,14 +115,20 @@ SPEC REPOS:
 EXTERNAL SOURCES:
   Apollo:
     :git: https://github.com/apollographql/apollo-ios.git
+  AppDevAnnouncements:
+    :git: https://github.com/cuappdev/appdev-announcements.git
 
 CHECKOUT OPTIONS:
   Apollo:
     :commit: 43dd373b9a64cd877f6331be6c56b24c125ca778
     :git: https://github.com/apollographql/apollo-ios.git
+  AppDevAnnouncements:
+    :commit: df02a92d50f0adc131359d4f51b76b4fd595759b
+    :git: https://github.com/cuappdev/appdev-announcements.git
 
 SPEC CHECKSUMS:
   Apollo: 09002d68c46e4098766fe376151d9ff8bd6aad36
+  AppDevAnnouncements: da6074ec0011c8964caa11cabc959ca007cb958f
   ARCL: 5fd2b0d7aabf91f15dbc0e8c510b25516b8a755a
   BulletinBoard: c774340545b5cfd05a96a89f63b105ecc95c86f9
   CHIPageControl: a787bf7205c9b7e7fbfc412be36c5e8636b68f86
@@ -141,6 +149,6 @@ SPEC CHECKSUMS:
   SwiftyJSON: c29297daf073d2aa016295d5809cdd68045c39b3
   SwiftyUserDefaults: 33fcb42bd1feb53a37d873feb62c82967db5f7f6
 
-PODFILE CHECKSUM: 1c5d8dde84bdc9fd451aeff03150714afe7dc373
+PODFILE CHECKSUM: 001412e9dcee71b81e01610fd92688768c99c741
 
 COCOAPODS: 1.8.4

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -123,7 +123,7 @@ CHECKOUT OPTIONS:
     :commit: 43dd373b9a64cd877f6331be6c56b24c125ca778
     :git: https://github.com/apollographql/apollo-ios.git
   AppDevAnnouncements:
-    :commit: df02a92d50f0adc131359d4f51b76b4fd595759b
+    :commit: 31c4502ac6e9e77e3c478bc46b4e4960cfc90fe9
     :git: https://github.com/cuappdev/appdev-announcements.git
 
 SPEC CHECKSUMS:

--- a/README.md
+++ b/README.md
@@ -14,12 +14,31 @@ We use [CocoaPods](http://cocoapods.org) for our dependency manager. This should
 To access the project, clone the project, and run `pod install` in the project directory.
 
 ### 2. Configuration
-We use [Firebase](https://firebase.google.com) for our user analytics. You will have to retrieve a `GoogleService-Info.plist` from Firebase and then place it inside the `Eatery/` directory.
+1. We use [Firebase](https://firebase.google.com) for our user analytics. You will have to retrieve a `GoogleService-Info.plist` from Firebase and then place it inside the `Eatery/` directory.
 
-We also use `GraphQL` to retrieve data from our backend server and use `Apollo` on the client side in order to help us do so. 
+2. We also use `GraphQL` to retrieve data from our backend server and use `Apollo` on the client side in order to help us do so. 
 
 To setup `Apollo`, you will have to first install it by running `npm install -g apollo@1.9` in the project directory (make sure you specify version 1.9).
 
 You will also have to retrieve a `schema.json` file by running: `apollo schema:download --endpoint={Backend_URL} schema.json` in the <strong>project directory</strong>.
+
+3. Lastly, you will need a `Secrets.plist` file that you will want to place inside the `Eatery/Supporting/` directory. The following is a template for the `Secrets.plist` file:
+
+```
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>announcements-scheme</key>
+	<string>insert-value-here</string>
+	<key>announcements-host</key>
+	<string>insert-value-here</string>
+	<key>announcements-common-path</key>
+	<string>insert-value-here</string>
+	<key>announcements-path</key>
+	<string>insert-value-here</string>
+</dict>
+</plist>
+```
 
 Finally, open `Eatery.xcworkspace` and enjoy Eatery!


### PR DESCRIPTION


## Overview

<!-- Summarize your changes here. -->
This PR integrates the `AppDevAnnouncements` cocoapod & updates the README with new onboarding instructions


## Changes Made

<!-- Include details of what your changes actually are and how it is intended to work. -->
- Adds setup for `AppDevAnnouncements` into `AppDelegate.swift`
- Presents new announcements upon startup of the app if there are any new ones to present
- Adds a new `Secrets.plist` file which is located under the `Eatery/Supporting/` directory


## Test Coverage

<!-- Describe how you tested this feature. Manual testing and/or unit testing. Please include repro steps and/or how to turn the feature on if applicable. -->

Ran the app and made sure that new announcements get displayed and that they only get shown once.


## Screenshots (delete if not applicable)

<!-- This could include of screenshots of the new feature / proof that the changes work. -->

<details>

![2020-02-22 01 12 04](https://user-images.githubusercontent.com/26048121/75087611-ac7e0880-5510-11ea-9209-1625cf55080c.gif)
  

</details>
