### PR TITLE
Rearrange hierarchy for Eateries view controller

### DIFF
--- a/Eatery.xcodeproj/xcshareddata/xcschemes/Eatery.xcscheme
+++ b/Eatery.xcodeproj/xcshareddata/xcschemes/Eatery.xcscheme
@@ -49,7 +49,7 @@
       ignoresPersistentStateOnLaunch = "NO"
       debugDocumentVersioning = "YES"
       debugServiceExtension = "internal"
-      allowLocationSimulation = "YES">
+      allowLocationSimulation = "NO">
       <BuildableProductRunnable
          runnableDebuggingMode = "0">
          <BuildableReference

--- a/Eatery/AppDelegate.swift
+++ b/Eatery/AppDelegate.swift
@@ -75,7 +75,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     }
 
     func handleShortcutItem(_ shortcutItem: UIApplicationShortcutItem) -> Bool {
-        eateryTabBarController.eateriesSharedViewController.campusEateriesViewController.preselectEatery(withName: shortcutItem.type)
+        eateryTabBarController.eateriesSharedViewController.preselectEatery(withName: shortcutItem.type)
         
         return true
     }

--- a/Eatery/Controllers/Eateries/Campus/CampusEateriesViewController.swift
+++ b/Eatery/Controllers/Eateries/Campus/CampusEateriesViewController.swift
@@ -90,17 +90,6 @@ class CampusEateriesViewController: EateriesViewController {
         pushPreselectedEateryIfPossible()
     }
 
-    override func pushMapViewController() {
-        super.pushMapViewController()
-
-        guard let eateries = allEateries else {
-            return
-        }
-
-        let mapViewController = MapViewController(eateries: eateries)
-        navigationController?.pushViewController(mapViewController, animated: true)
-    }
-
     private func pushPreselectedEateryIfPossible() {
         guard let name = preselectedEateryName else {
             return
@@ -146,6 +135,10 @@ class CampusEateriesViewController: EateriesViewController {
 // MARK: - Eateries View Controller Data Source
 
 extension CampusEateriesViewController: EateriesViewControllerDataSource {
+
+    func eateriesToPresentInMapViewController(_ evc: EateriesViewController) -> [Eatery] {
+        return allEateries ?? []
+    }
 
     func eateriesViewController(_ evc: EateriesViewController,
                                 eateriesToPresentWithSearchText searchText: String,

--- a/Eatery/Controllers/Eateries/Campus/CampusEateriesViewController.swift
+++ b/Eatery/Controllers/Eateries/Campus/CampusEateriesViewController.swift
@@ -90,6 +90,17 @@ class CampusEateriesViewController: EateriesViewController {
         pushPreselectedEateryIfPossible()
     }
 
+    override func pushMapViewController() {
+        super.pushMapViewController()
+
+        guard let eateries = allEateries else {
+            return
+        }
+
+        let mapViewController = MapViewController(eateries: eateries)
+        navigationController?.pushViewController(mapViewController, animated: true)
+    }
+
     private func pushPreselectedEateryIfPossible() {
         guard let name = preselectedEateryName else {
             return
@@ -298,15 +309,6 @@ extension CampusEateriesViewController: EateriesViewControllerDelegate {
         Timer.scheduledTimer(withTimeInterval: 0.5, repeats: false) { _ in
             self.queryCampusEateries()
         }
-    }
-
-    func eateriesViewControllerDidPushMapViewController(_ evc: EateriesViewController) {
-        guard let eateries = allEateries else {
-            return
-        }
-
-        let mapViewController = MapViewController(eateries: eateries)
-        navigationController?.pushViewController(mapViewController, animated: true)
     }
 
     func eateriesViewControllerDidRefreshEateries(_ evc: EateriesViewController) {

--- a/Eatery/Controllers/Eateries/Collegetown/CollegetownEateriesViewController.swift
+++ b/Eatery/Controllers/Eateries/Collegetown/CollegetownEateriesViewController.swift
@@ -48,17 +48,6 @@ class CollegetownEateriesViewController: EateriesViewController {
         }
     }
 
-    override func pushMapViewController() {
-        super.pushMapViewController()
-
-        guard let eateries = allEateries else {
-            return
-        }
-
-        let mapViewController = MapViewController(eateries: eateries)
-        navigationController?.pushViewController(mapViewController, animated: true)
-    }
-
     private func showMenu(of eatery: CollegetownEatery) {
         let menuViewController = CollegetownMenuViewController(eatery: eatery, userLocation: userLocation)
         navigationController?.pushViewController(menuViewController, animated: true)
@@ -74,6 +63,10 @@ class CollegetownEateriesViewController: EateriesViewController {
 // MARK: -
 
 extension CollegetownEateriesViewController: EateriesViewControllerDataSource {
+
+    func eateriesToPresentInMapViewController(_ evc: EateriesViewController) -> [Eatery] {
+        return allEateries ?? []
+    }
 
     func eateriesViewController(_ evc: EateriesViewController, eateriesToPresentWithSearchText searchText: String, filters: Set<Filter>) -> [Eatery] {
         guard let eateries = allEateries else {

--- a/Eatery/Controllers/Eateries/Collegetown/CollegetownEateriesViewController.swift
+++ b/Eatery/Controllers/Eateries/Collegetown/CollegetownEateriesViewController.swift
@@ -48,6 +48,17 @@ class CollegetownEateriesViewController: EateriesViewController {
         }
     }
 
+    override func pushMapViewController() {
+        super.pushMapViewController()
+
+        guard let eateries = allEateries else {
+            return
+        }
+
+        let mapViewController = MapViewController(eateries: eateries)
+        navigationController?.pushViewController(mapViewController, animated: true)
+    }
+
     private func showMenu(of eatery: CollegetownEatery) {
         let menuViewController = CollegetownMenuViewController(eatery: eatery, userLocation: userLocation)
         navigationController?.pushViewController(menuViewController, animated: true)

--- a/Eatery/Controllers/Eateries/EateriesSharedViewController.swift
+++ b/Eatery/Controllers/Eateries/EateriesSharedViewController.swift
@@ -20,19 +20,19 @@ class EateriesSharedViewController: UIViewController {
 
     // View Controllers
 
-    private lazy var campusEateries = CampusEateriesViewController()
-    private lazy var campusNavigation = EateryNavigationController(rootViewController: campusEateries)
-    private lazy var collegetownEateries = CollegetownEateriesViewController()
-    private lazy var collegetownNavigation = EateryNavigationController(rootViewController: collegetownEateries)
+    private lazy var campusEateriesVC = CampusEateriesViewController()
+    private lazy var campusNavigationVC = EateryNavigationController(rootViewController: campusEateriesVC)
+    private lazy var collegetownEateriesVC = CollegetownEateriesViewController()
+    private lazy var collegetownNavigationVC = EateryNavigationController(rootViewController: collegetownEateriesVC)
     private lazy var pillViewController = PillViewController(
-        leftViewController: campusNavigation,
-        rightViewController: collegetownNavigation
+        leftViewController: campusNavigationVC,
+        rightViewController: collegetownNavigationVC
     )
 
     var activeViewController: EateriesViewController {
         pillViewController.pillView.leftSegmentSelected
-            ? campusEateries
-            : collegetownEateries
+            ? campusEateriesVC
+            : collegetownEateriesVC
     }
 
     // Location
@@ -78,15 +78,15 @@ class EateriesSharedViewController: UIViewController {
     }
 
     func preselectEatery(withName name: String) {
-        campusEateries.preselectEatery(withName: name)
+        campusEateriesVC.preselectEatery(withName: name)
     }
 
     private func setUpEateriesViewControllers() {
-        campusNavigation.delegate = self
-        collegetownNavigation.delegate = self
+        campusNavigationVC.delegate = self
+        collegetownNavigationVC.delegate = self
 
-        campusEateries.scrollDelegate = self
-        collegetownEateries.scrollDelegate = self
+        campusEateriesVC.scrollDelegate = self
+        collegetownEateriesVC.scrollDelegate = self
 
         addChildViewController(pillViewController)
         view.addSubview(pillViewController.view)
@@ -129,8 +129,8 @@ class EateriesSharedViewController: UIViewController {
 
     private func updateShowPill() {
         let showPill =
-            (pillViewController.pillView.leftSegmentSelected && campusNavigation.viewControllers.count == 1)
-            || (!pillViewController.pillView.leftSegmentSelected && collegetownNavigation.viewControllers.count == 1)
+            (pillViewController.pillView.leftSegmentSelected && campusNavigationVC.viewControllers.count == 1)
+            || (!pillViewController.pillView.leftSegmentSelected && collegetownNavigationVC.viewControllers.count == 1)
 
         pillViewController.setShowPill(showPill, animated: true)
     }
@@ -182,8 +182,8 @@ extension EateriesSharedViewController: CLLocationManagerDelegate {
     func locationManager(_ manager: CLLocationManager, didUpdateLocations locations: [CLLocation]) {
         let userLocation = locations.last
 
-        campusEateries.userLocation = userLocation
-        collegetownEateries.userLocation = userLocation
+        campusEateriesVC.userLocation = userLocation
+        collegetownEateriesVC.userLocation = userLocation
     }
 
 }

--- a/Eatery/Controllers/Eateries/EateriesSharedViewController.swift
+++ b/Eatery/Controllers/Eateries/EateriesSharedViewController.swift
@@ -128,8 +128,9 @@ class EateriesSharedViewController: UIViewController {
     }
 
     private func updateShowPill() {
-        let showPill = pillViewController.pillView.leftSegmentSelected && campusNavigation.viewControllers.count == 1
-            || !pillViewController.pillView.leftSegmentSelected && collegetownNavigation.viewControllers.count == 1
+        let showPill =
+            (pillViewController.pillView.leftSegmentSelected && campusNavigation.viewControllers.count == 1)
+            || (!pillViewController.pillView.leftSegmentSelected && collegetownNavigation.viewControllers.count == 1)
 
         pillViewController.setShowPill(showPill, animated: true)
     }

--- a/Eatery/Controllers/Eateries/EateriesViewController.swift
+++ b/Eatery/Controllers/Eateries/EateriesViewController.swift
@@ -28,6 +28,8 @@ protocol EateriesViewControllerDataSource: AnyObject {
                                 searchText: String,
                                 filters: Set<Filter>) -> NSAttributedString?
 
+    func eateriesToPresentInMapViewController(_ evc: EateriesViewController) -> [Eatery]
+
 }
 
 // MARK: - Delegate
@@ -553,6 +555,11 @@ class EateriesViewController: UIViewController {
 
     @objc func pushMapViewController() {
         AppDevAnalytics.shared.logFirebase(MapPressPayload())
+
+        guard let eateries = dataSource?.eateriesToPresentInMapViewController(self) else { return }
+
+        let mapViewController = MapViewController(eateries: eateries)
+        navigationController?.pushViewController(mapViewController, animated: true)
     }
 
     // MARK: Scroll View

--- a/Eatery/Controllers/Eateries/EateriesViewController.swift
+++ b/Eatery/Controllers/Eateries/EateriesViewController.swift
@@ -40,8 +40,6 @@ protocol EateriesViewControllerDelegate: AnyObject {
 
     func eateriesViewControllerDidPressRetryButton(_ evc: EateriesViewController)
 
-    func eateriesViewControllerDidPushMapViewController(_ evc: EateriesViewController)
-
     func eateriesViewControllerDidRefreshEateries(_ evc: EateriesViewController)
 
 }
@@ -148,7 +146,7 @@ class EateriesViewController: UIViewController {
     weak var delegate: EateriesViewControllerDelegate?
     weak var scrollDelegate: EateriesViewControllerScrollDelegate?
     
-    var appDevLogo: UIView?
+    private var appDevLogo: UIView?
     
     private var gridLayout: EateriesCollectionViewGridLayout!
     private var collectionView: UICollectionView!
@@ -175,7 +173,13 @@ class EateriesViewController: UIViewController {
         }
     }
 
-    // Preselection
+    // Caching
+
+    private let networkActivityIndicator = NVActivityIndicatorView(
+        frame: CGRect(x: 0, y: 0, width: 22, height: 22),
+        type: .circleStrokeSpin,
+        color: .white
+    )
 
     /// The eatery to present after we switch presentation modes.
     private var preselectedEatery: Eatery?
@@ -189,6 +193,7 @@ class EateriesViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
 
+        setUpNavigationBar()
         setUpCollectionView()
         setUpSearchAndFilterBars()
         setUpActivityIndicator()
@@ -204,7 +209,47 @@ class EateriesViewController: UIViewController {
 
         registerForEateryIsFavoriteDidChangeNotification()
     }
-    
+
+    override func didMove(toParentViewController parent: UIViewController?) {
+        super.didMove(toParentViewController: parent)
+
+        // Adjust the navigation bar down when the app first launches.
+        // Why put this in didMove(toParentViewController:)? This code block should only be called once when the app
+        // launches, but after the view has been added to the view hiearchy so that we can compute the adjusted
+        // content inset.
+        let navigationBarLargeTitleHeight: CGFloat = 52
+        collectionView.setContentOffset(
+            CGPoint(x: 0, y: -(collectionView.adjustedContentInset.top + navigationBarLargeTitleHeight)),
+            animated: false)
+    }
+
+    private func setUpNavigationBar() {
+        navigationItem.title = "Eateries"
+        navigationItem.largeTitleDisplayMode = .automatic
+
+        let heroEnabled = !UIAccessibility.isReduceMotionEnabled
+        navigationController?.hero.isEnabled = heroEnabled
+        navigationController?.hero.navigationAnimationType = .fade
+        hero.isEnabled = heroEnabled
+
+        let mapButton = UIBarButtonItem(image: #imageLiteral(resourceName: "mapIcon"), style: .done, target: self, action: #selector(pushMapViewController))
+        mapButton.imageInsets = UIEdgeInsets(top: 0.0, left: 8.0, bottom: 4.0, right: 8.0)
+        navigationItem.rightBarButtonItems = [mapButton]
+
+        navigationItem.leftBarButtonItem = UIBarButtonItem(customView: networkActivityIndicator)
+
+        let logo = UIImageView(image: UIImage(named: "appDevLogo"))
+        logo.tintColor = .eateryBlue
+        logo.contentMode = .scaleAspectFit
+        navigationController?.navigationBar.addSubview(logo)
+        logo.snp.makeConstraints { make in
+            make.center.equalToSuperview()
+            make.size.equalTo(28.0)
+        }
+
+        appDevLogo = logo
+    }
+
     private func setUpCollectionView() {
         gridLayout = EateriesCollectionViewGridLayout()
         
@@ -215,7 +260,7 @@ class EateriesViewController: UIViewController {
         collectionView.delaysContentTouches = false
         collectionView.dataSource = self
         collectionView.delegate = self
-        collectionView.prefetchDataSource = self
+        collectionView.contentInsetAdjustmentBehavior = .always
         collectionView.register(UICollectionViewCell.self,
                                 forCellWithReuseIdentifier: CellIdentifier.container.rawValue)
         collectionView.register(EateryCollectionViewCell.self,
@@ -306,7 +351,7 @@ class EateriesViewController: UIViewController {
             case .failedToLoad, .loading:
                 fadeOut(views: [collectionView, searchBar, filterBar], animated: animated)
             default:
-                break
+                networkActivityIndicator.stopAnimating()
             }
 
         case .failedToLoad:
@@ -321,6 +366,7 @@ class EateriesViewController: UIViewController {
 
         case .presenting(let cached):
             searchBar.isUserInteractionEnabled = !cached
+            cached ? networkActivityIndicator.startAnimating() : networkActivityIndicator.stopAnimating()
 
             switch state {
             case .failedToLoad, .loading:
@@ -505,17 +551,14 @@ class EateriesViewController: UIViewController {
 
     // MARK: Map View
 
-    func pushMapViewController() {
-        delegate?.eateriesViewControllerDidPushMapViewController(self)
+    @objc func pushMapViewController() {
+        AppDevAnalytics.shared.logFirebase(MapPressPayload())
     }
 
     // MARK: Scroll View
     
-    func scrollToTop() {
-        if collectionView.contentOffset.y > 0 {
-            let contentOffset = -(filterBar.frame.height + (navigationController?.navigationBar.frame.height ?? 0))
-            collectionView.setContentOffset(CGPoint(x: 0, y: contentOffset), animated: true)
-        }
+    func scrollToTop(animated: Bool) {
+        collectionView.setContentOffset(CGPoint(x: 0, y: -collectionView.adjustedContentInset.top), animated: animated)
     }
     
     override func viewWillLayoutSubviews() {

--- a/Eatery/Controllers/Eateries/PillViewController.swift
+++ b/Eatery/Controllers/Eateries/PillViewController.swift
@@ -41,7 +41,8 @@ class PillViewController: UIViewController {
         }
     }
 
-    private let containerView = UIView()
+    private let containerController = UIViewController()
+    private var containerView: UIView { containerController.view }
     let leftViewController: UIViewController
     let rightViewController: UIViewController
 
@@ -62,25 +63,28 @@ class PillViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
 
+        addChildViewController(containerController)
+        containerController.additionalSafeAreaInsets = UIEdgeInsets(top: 0, left: 0, bottom: 56, right: 0)
         containerView.backgroundColor = .clear
         view.addSubview(containerView)
         containerView.snp.makeConstraints { make in
             make.edges.equalToSuperview()
         }
+        containerController.didMove(toParentViewController: self)
 
-        addChildViewController(leftViewController)
+        containerController.addChildViewController(leftViewController)
         containerView.addSubview(leftViewController.view)
         leftViewController.view.snp.makeConstraints { make in
             make.edges.equalToSuperview()
         }
-        leftViewController.didMove(toParentViewController: self)
+        leftViewController.didMove(toParentViewController: containerController)
 
-        addChildViewController(rightViewController)
+        containerController.addChildViewController(rightViewController)
         containerView.addSubview(rightViewController.view)
         rightViewController.view.snp.makeConstraints { make in
             make.edges.equalToSuperview()
         }
-        rightViewController.didMove(toParentViewController: self)
+        rightViewController.didMove(toParentViewController: containerController)
 
         pillView.addTarget(self, action: #selector(pillSelectionDidChange), for: .valueChanged)
         view.addSubview(pillView)
@@ -95,10 +99,6 @@ class PillViewController: UIViewController {
         hidePillConstraints = pillView.snp.prepareConstraints { make in
             make.top.equalTo(view.snp.bottom).offset(8)
         }
-
-        leftViewController.view.preservesSuperviewLayoutMargins = true
-        rightViewController.view.preservesSuperviewLayoutMargins = true
-        containerView.layoutMargins = UIEdgeInsets(top: 0, left: 0, bottom: 56, right: 0)
 
         setShowPill(true, animated: false)
         if pillView.leftSegmentSelected {

--- a/Eatery/Controllers/EateryNavigationController.swift
+++ b/Eatery/Controllers/EateryNavigationController.swift
@@ -13,7 +13,6 @@ class EateryNavigationController: UINavigationController {
     override func viewDidLoad() {
         super.viewDidLoad()
 
-        delegate = self
         // allow swipe back gesture even if navigation bar is hidden
         interactivePopGestureRecognizer?.delegate = nil
 
@@ -28,17 +27,6 @@ class EateryNavigationController: UINavigationController {
             navigationBar.largeTitleTextAttributes = [.foregroundColor: UIColor.white]
             navigationBar.isTranslucent = false
         }
-    }
-
-}
-
-extension EateryNavigationController: UINavigationControllerDelegate {
-
-    func navigationController(_ navigationController: UINavigationController, willShow viewController: UIViewController, animated: Bool) {
-        viewController.extendedLayoutIncludesOpaqueBars = true
-
-        let isParallax = viewController is ImageParallaxScrollViewController
-        setNavigationBarHidden(isParallax, animated: true)
     }
 
 }

--- a/Eatery/Controllers/EateryTabBarController.swift
+++ b/Eatery/Controllers/EateryTabBarController.swift
@@ -44,8 +44,7 @@ class EateryTabBarController: UITabBarController {
 
     override func viewDidLoad() {
         delegate = self
-        let eateriesNavigationController = EateryNavigationController(rootViewController: eateriesSharedViewController)
-        eateriesNavigationController.tabBarItem = UITabBarItem(title: nil, image: UIImage(named: "eateryTabIcon.png"), tag: 0)
+        eateriesSharedViewController.tabBarItem = UITabBarItem(title: nil, image: UIImage(named: "eateryTabIcon.png"), tag: 0)
 
         let lookAheadNavigationController = EateryNavigationController(rootViewController: lookAheadViewController)
         lookAheadNavigationController.tabBarItem = UITabBarItem(title: nil, image: #imageLiteral(resourceName: "menu icon"), tag: 1)
@@ -53,7 +52,7 @@ class EateryTabBarController: UITabBarController {
         let brbNavigationController = EateryNavigationController(rootViewController: brbViewController)
         brbNavigationController.tabBarItem = UITabBarItem(title: nil, image: UIImage(named: "accountIcon.png"), tag: 2)
 
-        let navigationControllers = [eateriesNavigationController, lookAheadNavigationController, brbNavigationController]
+        let navigationControllers = [eateriesSharedViewController, lookAheadNavigationController, brbNavigationController]
         navigationControllers.forEach { $0.tabBarItem.imageInsets = UIEdgeInsets(top: 6, left: 0, bottom: -6, right: 0) }
 
         setViewControllers(navigationControllers, animated: false)
@@ -87,9 +86,8 @@ extension EateryTabBarController: UITabBarControllerDelegate {
 
     func tabBarController(_ tabBarController: UITabBarController, shouldSelect viewController: UIViewController) -> Bool {
         if selectedViewController === viewController,
-            let navigationController = viewController as? UINavigationController,
-            let eateriesSharedVC = navigationController.viewControllers.first as? EateriesSharedViewController {
-            eateriesSharedVC.activeViewController.scrollToTop()
+            let shared = viewController as? EateriesSharedViewController {
+            shared.activeViewController.scrollToTop(animated: true)
         }
 
         return true

--- a/Shared/Network/NetworkManager.swift
+++ b/Shared/Network/NetworkManager.swift
@@ -196,7 +196,7 @@ struct NetworkManager {
 
             guard let result = result,
                 let data = result.data,
-                let graphQlEateries = data.collegetownEateries?.compactMap({ $0 }) else {
+                let graphQlEateries = data.collegetownEateriesVC?.compactMap({ $0 }) else {
                     completion(nil, NetworkError(message: "Could not parse response"))
                     return
             }


### PR DESCRIPTION
<!-- IF A SECTION IS NOT APPLICABLE TO YOU, PLEASE DELETE IT!! -->

<!-- Your title should be able to summarize what changes you've made in one sentence. For example: "Exclude staff from the check for follows". For stacked PRs, please indicate clearly in the title where in the stack you are. For example: "[Eatery Refactor][4/5] Converted all files to MVP model" -->

## Overview

<!-- Summarize your changes here. -->

Rearrange the view controller hierarchy by adding a navigation controller for both the campus and collegetown eatery VCs. 

This refactoring was done to make way for improved search. 

I spent most of my time dealing with a frustrating UIKit bug where the navigation bar appear compact when the app loaded. If anyone has information about what could be causing this please let me know.

## Changes Made

<!-- Include details of what your changes actually are and how it is intended to work. -->

Originally, the view controller hierarchy looked like this:

- Eatery Navigation VC
  - Eateries Shared VC
    - Pill VC
      - Campus Eatery VC
      - Collegetown Eatery VC

Now, the view controller hierarchy is arranged:

- Eateries Shared VC
  - Pill VC
    - Eatery Navigation VC
      - Campus Eatery VC
    - Eatery Navigation VC
      - Collegetown Eatery VC

## Test Coverage

<!-- Describe how you tested this feature. Manual testing and/or unit testing. Please include repro steps and/or how to turn the feature on if applicable. -->

Manual testing on device

## Related PRs or Issues (delete if not applicable)

<!-- List related PRs against other branches/repositories. -->

#273