### PR TITLE
Fix state transition visual bugs

### DIFF
--- a/Eatery/Controllers/Eateries/Campus/CampusEateriesViewController.swift
+++ b/Eatery/Controllers/Eateries/Campus/CampusEateriesViewController.swift
@@ -301,8 +301,8 @@ extension CampusEateriesViewController: EateriesViewControllerDelegate {
     }
 
     func eateriesViewControllerDidRefreshEateries(_ evc: EateriesViewController) {
-        queryCampusEateries()
         updateState(.loading, animated: true)
+        queryCampusEateries()
     }
 
 }

--- a/Eatery/Controllers/Eateries/Campus/CampusEateriesViewController.swift
+++ b/Eatery/Controllers/Eateries/Campus/CampusEateriesViewController.swift
@@ -297,19 +297,12 @@ extension CampusEateriesViewController: EateriesViewControllerDelegate {
 
     func eateriesViewControllerDidPressRetryButton(_ evc: EateriesViewController) {
         updateState(.loading, animated: true)
-
-        // Delay the reload to give the impression that the app is querying
-        Timer.scheduledTimer(withTimeInterval: 0.5, repeats: false) { _ in
-            self.queryCampusEateries()
-        }
+        queryCampusEateries()
     }
 
     func eateriesViewControllerDidRefreshEateries(_ evc: EateriesViewController) {
+        queryCampusEateries()
         updateState(.loading, animated: true)
-
-        Timer.scheduledTimer(withTimeInterval: 0.5, repeats: false) { _ in
-            self.queryCampusEateries()
-        }
     }
 
 }

--- a/Eatery/Controllers/Eateries/EateriesViewController.swift
+++ b/Eatery/Controllers/Eateries/EateriesViewController.swift
@@ -207,8 +207,6 @@ class EateriesViewController: UIViewController {
         activityIndicator.alpha = 0
         failedToLoadView.alpha = 0
 
-        scheduleUpdateTimer()
-
         registerForEateryIsFavoriteDidChangeNotification()
     }
 
@@ -344,6 +342,8 @@ class EateriesViewController: UIViewController {
     }
 
     func updateState(_ newState: State, animated: Bool) {
+        updateTimer?.invalidate()
+
         switch state {
         case .loading:
             fadeOut(views: [activityIndicator], animated: animated, completion: activityIndicator.stopAnimating)
@@ -372,9 +372,9 @@ class EateriesViewController: UIViewController {
 
             switch state {
             case .failedToLoad, .loading:
-                fadeIn(views: [collectionView, searchBar, filterBar], animated: animated)
+                reloadEateries(animated: false)
 
-                reloadEateries(animated: animated)
+                fadeIn(views: [collectionView, searchBar, filterBar], animated: animated)
 
                 if animated {
                     animateCollectionViewCells()
@@ -385,6 +385,7 @@ class EateriesViewController: UIViewController {
             }
 
             pushPreselectedEateryIfPossible()
+            scheduleUpdateTimer()
 
         case .failedToLoad:
             fadeIn(views: [failedToLoadView], animated: animated)
@@ -580,7 +581,7 @@ class EateriesViewController: UIViewController {
         // update the timer on the minute
         let seconds = 60 - (Calendar.current.dateComponents([.second], from: Date()).second ?? 0)
 
-        updateTimer = Timer.scheduledTimer(withTimeInterval: TimeInterval(seconds), repeats: false) { [weak self] _ in
+        updateTimer = Timer.scheduledTimer(withTimeInterval: 5, repeats: false) { [weak self] _ in
             guard let self = self else { return }
             print("Updating \(type(of: self))", Date())
             self.reloadEateries(animated: false)

--- a/Eatery/Controllers/Eateries/EateriesViewController.swift
+++ b/Eatery/Controllers/Eateries/EateriesViewController.swift
@@ -581,7 +581,7 @@ class EateriesViewController: UIViewController {
         // update the timer on the minute
         let seconds = 60 - (Calendar.current.dateComponents([.second], from: Date()).second ?? 0)
 
-        updateTimer = Timer.scheduledTimer(withTimeInterval: 5, repeats: false) { [weak self] _ in
+        updateTimer = Timer.scheduledTimer(withTimeInterval: TimeInterval(seconds), repeats: false) { [weak self] _ in
             guard let self = self else { return }
             print("Updating \(type(of: self))", Date())
             self.reloadEateries(animated: false)

--- a/Eatery/Controllers/Eateries/EateriesViewController.swift
+++ b/Eatery/Controllers/Eateries/EateriesViewController.swift
@@ -169,6 +169,8 @@ class EateriesViewController: UIViewController {
 
     var userLocation: CLLocation? {
         didSet {
+            loadViewIfNeeded()
+
             for cell in collectionView.visibleCells.compactMap({ $0 as? EateryCollectionViewCell }) {
                 cell.userLocation = userLocation
             }

--- a/Shared/Network/NetworkManager.swift
+++ b/Shared/Network/NetworkManager.swift
@@ -196,7 +196,7 @@ struct NetworkManager {
 
             guard let result = result,
                 let data = result.data,
-                let graphQlEateries = data.collegetownEateriesVC?.compactMap({ $0 }) else {
+                let graphQlEateries = data.collegetownEateries?.compactMap({ $0 }) else {
                     completion(nil, NetworkError(message: "Could not parse response"))
                     return
             }


### PR DESCRIPTION
<!-- IF A SECTION IS NOT APPLICABLE TO YOU, PLEASE DELETE IT!! -->

<!-- Your title should be able to summarize what changes you've made in one sentence. For example: "Exclude staff from the check for follows". For stacked PRs, please indicate clearly in the title where in the stack you are. For example: "[Eatery Refactor][4/5] Converted all files to MVP model" -->

## Overview

<!-- Summarize your changes here. -->

Fix bugs related to state transitions in the Eateries View Controller. 
1. Manually refreshing Eateries would cause the Eateries to flash, then animate in the remaining Eateries
2. Occasionally, during animation, the Eatery cells would snap to their final position.

## Changes Made

<!-- Include details of what your changes actually are and how it is intended to work. -->

1. Caused by a reload after fading in the collection view that cancelled the fade in animation. 

   I moved the fade in animation to be after the reload. 
2. Caused by the update timer triggering while the eateries were animating.

   I invalidate the update timer when state transitions occur, and only activate it when we are presenting Eateries

## Test Coverage

Manual testing on device.
