### PR TITLE
[Improved Search][Part 3] Integrate Search Results

### DIFF
--- a/Eatery/Controllers/Eateries/Collegetown/CollegetownEateriesViewController.swift
+++ b/Eatery/Controllers/Eateries/Collegetown/CollegetownEateriesViewController.swift
@@ -104,4 +104,33 @@ extension CollegetownEateriesViewController: EateriesViewControllerDelegate {
         }
     }
 
+    func eateriesViewController(_ evc: EateriesViewController, filter eateries: [Eatery], with filters: Set<Filter>) -> [Eatery] {
+        guard var filteredEateries = eateries as? [CollegetownEatery] else {
+            return eateries
+        }
+
+        let selectedCategoryFilters = filters.intersection(Filter.categoryFilters).map { $0.rawValue }
+        if !selectedCategoryFilters.isEmpty {
+            filteredEateries = filteredEateries.filter { eatery -> Bool in
+                // check if an eatery has a category that is also in the
+                // selected category filters
+                eatery.categories.contains { eateryCategory -> Bool in
+                    selectedCategoryFilters.contains { filterCategory -> Bool in
+                        search(eateryCategory, matches: filterCategory) || search(filterCategory, matches: eateryCategory)
+                    }
+                }
+            }
+        }
+
+        return filteredEateries
+    }
+
+    private func matchRange(of searchText: String, in text: String) -> Range<String.Index>? {
+        return text.range(of: searchText, options: [.caseInsensitive, .diacriticInsensitive])
+    }
+
+    private func search(_ searchText: String, matches text: String) -> Bool {
+        return matchRange(of: searchText, in: text) != nil
+    }
+
 }

--- a/Eatery/Controllers/Eateries/EateriesSharedViewController.swift
+++ b/Eatery/Controllers/Eateries/EateriesSharedViewController.swift
@@ -83,10 +83,11 @@ class EateriesSharedViewController: UIViewController {
 
     private func setUpEateriesViewControllers() {
         campusNavigationVC.delegate = self
-        collegetownNavigationVC.delegate = self
-
         campusEateriesVC.scrollDelegate = self
+
+        collegetownNavigationVC.delegate = self
         collegetownEateriesVC.scrollDelegate = self
+        collegetownEateriesVC.loadViewIfNeeded()
 
         addChildViewController(pillViewController)
         view.addSubview(pillViewController.view)

--- a/Eatery/Controllers/Eateries/EateriesViewController.swift
+++ b/Eatery/Controllers/Eateries/EateriesViewController.swift
@@ -23,6 +23,8 @@ protocol EateriesViewControllerDelegate: AnyObject {
 
     func eateriesViewControllerDidRefreshEateries(_ evc: EateriesViewController)
 
+    func eateriesViewController(_ evc: EateriesViewController, filter eateries: [Eatery], with filters: Set<Filter>) -> [Eatery]
+
 }
 
 // MARK: - Scroll Delegate
@@ -135,10 +137,13 @@ class EateriesViewController: UIViewController {
     private var collectionView: UICollectionView!
     private var refreshControl: UIRefreshControl!
 
-    private var searchBar: UISearchBar? {
-        return navigationItem.searchController?.searchBar
+    var searchController: UISearchController? {
+        return navigationItem.searchController
     }
-    private var filterBar: FilterBar!
+    private var searchBar: UISearchBar? {
+        return searchController?.searchBar
+    }
+    var filterBar: FilterBar!
     var availableFilters: [Filter] {
         get { return filterBar.displayedFilters }
         set { filterBar.displayedFilters = newValue }
@@ -201,7 +206,7 @@ class EateriesViewController: UIViewController {
         // launches, but after the view has been added to the view hiearchy so that we can compute the adjusted
         // content inset.
         let largeTitleHeight: CGFloat = 52
-        let searchBarHeight: CGFloat = 52
+        let searchBarHeight: CGFloat = searchBar != nil ? 52 : 0
         collectionView.setContentOffset(
             CGPoint(x: 0, y: -(collectionView.adjustedContentInset.top + largeTitleHeight + searchBarHeight)),
             animated: false)
@@ -231,13 +236,7 @@ class EateriesViewController: UIViewController {
             make.size.equalTo(28.0)
         }
 
-        navigationItem.searchController = setUpSearchController()
-
         appDevLogo = logo
-    }
-
-    func setUpSearchController() -> UISearchController? {
-        nil
     }
 
     private func setUpCollectionView() {
@@ -492,9 +491,8 @@ class EateriesViewController: UIViewController {
             sortMethod = .alphabetical
         }
 
-        let newEateriesByGroup = eateriesByGroup(
-            from: eateries,
-            sortedUsing: sortMethod)
+        let filteredEateries = delegate?.eateriesViewController(self, filter: eateries, with: filterBar.selectedFilters) ?? eateries
+        let newEateriesByGroup = eateriesByGroup(from: filteredEateries, sortedUsing: sortMethod)
 
         self.eateriesByGroup = newEateriesByGroup
 


### PR DESCRIPTION
## Overview

Integrate search results with the rest of Eatery, i.e. tap on a search result to open it.

## Changes Made

Connect the `CampusEateriesSearchViewController` to `CampusEateriesViewController` using a delegate. 

`UISearchController` behaves weirdly with how we're doing navigation bars. The search controller insists that there's a navigation bar (so it can show the search bar), but when we push a menu view controller we want the navigation bar to disappear so we can present our own "fake" transparent navigation bar. The `UISearchController` wins out and the navigation bar is presented in addition to our navigation bar. 

This all means I have to dismiss the `UISearchController` before I can present the search result. This is done by storing the `selectedSearchResult`, then waiting for a call from `UISearchController` when its done dismissing. 

Some other random things I did:
* Search filtering was readded (oops)
* Slight reworking of `FilterBar` so `selectedFilters` is the source of truth. 

## Test Coverage

<!-- Describe how you tested this feature. Manual testing and/or unit testing. Please include repro steps and/or how to turn the feature on if applicable. -->

Tested on a physical iPhone 11 running iOS 13

## Next Steps

<!-- If this is part of a multi-PR change, please describe what changes you plan on addressing in future PRs. -->

Collegetown 

## Related PRs or Issues

<!-- List related PRs against other branches/repositories. -->

#273 

## Screenshots (delete if not applicable)

<!-- This could include of screenshots of the new feature / proof that the changes work. -->

<details>

  <summary>Screen Shot Name</summary>


![RPReplay_Final1588518981](https://user-images.githubusercontent.com/1882991/80918035-ce75e180-8d30-11ea-8c5f-ec9081ef4083.gif)

  



</details>
