### PR TITLE
eatery: Change EateryType.dining.rawValue to 'dining room'

### DIFF
--- a/Shared/Models/Eatery.swift
+++ b/Shared/Models/Eatery.swift
@@ -37,9 +37,9 @@ enum PaymentMethod: String, Codable {
 }
 
 /// Different types of eateries on campus
-enum EateryType: String, Codable{
+enum EateryType: String, Codable {
 
-    case dining = "all you care to eat dining room"
+    case dining = "dining room"
     case cafe = "cafe"
     case cart = "cart"
     case foodCourt = "food court"


### PR DESCRIPTION
Change `EateryType.dining.rawValue` to `"dining room"` to match with Cornell's new description.

I think we'll want a more robust way to do this in the future. Could this be solved on the backend, or with regexes instead of exact string matches?