### PR TITLE
Info.plist: Remove newstand icon

### DIFF
--- a/Eatery/Info.plist
+++ b/Eatery/Info.plist
@@ -27,17 +27,6 @@
 			<key>UIPrerenderedIcon</key>
 			<false/>
 		</dict>
-		<key>UINewsstandIcon</key>
-		<dict>
-			<key>CFBundleIconFiles</key>
-			<array>
-				<string></string>
-			</array>
-			<key>UINewsstandBindingEdge</key>
-			<string>UINewsstandBindingEdgeLeft</string>
-			<key>UINewsstandBindingType</key>
-			<string>UINewsstandBindingTypeMagazine</string>
-		</dict>
 	</dict>
 	<key>CFBundleIdentifier</key>
 	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
@@ -66,7 +55,32 @@
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
 	<key>LSApplicationCategoryType</key>
-	<string>Icon-App-20x20@1x.pngIcon-App-20x20@2x-1.pngIcon-App-20x20@2x.pngIcon-App-20x20@3x.pngIcon-App-29x29@1x-1.pngIcon-App-29x29@1x.pngIcon-App-29x29@2x-1.pngIcon-App-29x29@2x.pngIcon-App-29x29@3x.pngIcon-App-40x40@1x.pngIcon-App-40x40@2x-1.pngIcon-App-40x40@2x.pngIcon-App-40x40@3x.pngIcon-App-57x57@1x.pngIcon-App-57x57@2x.pngIcon-App-60x60@2x.pngIcon-App-60x60@3x.pngIcon-App-72x72@1x.pngIcon-App-72x72@2x.pngIcon-App-76x76@1x.pngIcon-App-76x76@2x.pngIcon-App-83.5x83.5@2x.pngIcon-Small-50x50@1x.pngIcon-Small-50x50@2x.pngItunesArtwork@2x.pngwinter-logo.jpg</string>
+	<string>Icon-App-20x20@1x.png
+Icon-App-20x20@2x-1.png
+Icon-App-20x20@2x.png
+Icon-App-20x20@3x.png
+Icon-App-29x29@1x-1.png
+Icon-App-29x29@1x.png
+Icon-App-29x29@2x-1.png
+Icon-App-29x29@2x.png
+Icon-App-29x29@3x.png
+Icon-App-40x40@1x.png
+Icon-App-40x40@2x-1.png
+Icon-App-40x40@2x.png
+Icon-App-40x40@3x.png
+Icon-App-57x57@1x.png
+Icon-App-57x57@2x.png
+Icon-App-60x60@2x.png
+Icon-App-60x60@3x.png
+Icon-App-72x72@1x.png
+Icon-App-72x72@2x.png
+Icon-App-76x76@1x.png
+Icon-App-76x76@2x.png
+Icon-App-83.5x83.5@2x.png
+Icon-Small-50x50@1x.png
+Icon-Small-50x50@2x.png
+ItunesArtwork@2x.png
+winter-logo.jpg</string>
 	<key>LSApplicationQueriesSchemes</key>
 	<array>
 		<string>comgooglemaps</string>


### PR DESCRIPTION
Fix App Store Connect issue:
```
ITMS-90138: Your Info.plist contains the UINewsstandIcon sub-property under CFBundleIcons, which is intended for use with Newstand features. To include Newsstand features, the Info.plist must include the UINewsstandApp=true Info.plist key.
```