### PR TITLE
HoursThisWeek: Fix brunch hours

### DIFF
--- a/Eatery.xcodeproj/xcshareddata/xcschemes/Eatery Watch App (Notification).xcscheme
+++ b/Eatery.xcodeproj/xcshareddata/xcschemes/Eatery Watch App (Notification).xcscheme
@@ -56,8 +56,10 @@
       allowLocationSimulation = "YES"
       launchAutomaticallySubstyle = "8"
       notificationPayloadFile = "Eatery Watch App Extension/PushNotificationPayload.apns">
-      <BuildableProductRunnable
-         runnableDebuggingMode = "0">
+      <RemoteRunnable
+         runnableDebuggingMode = "2"
+         BundleIdentifier = "com.apple.Carousel"
+         RemotePath = "/Eatery">
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "5D05FF3123C2C14400EF8CC9"
@@ -65,7 +67,7 @@
             BlueprintName = "Eatery Watch App"
             ReferencedContainer = "container:Eatery.xcodeproj">
          </BuildableReference>
-      </BuildableProductRunnable>
+      </RemoteRunnable>
    </LaunchAction>
    <ProfileAction
       buildConfiguration = "Debug"
@@ -75,8 +77,10 @@
       debugDocumentVersioning = "YES"
       launchAutomaticallySubstyle = "8"
       notificationPayloadFile = "Eatery Watch App Extension/PushNotificationPayload.apns">
-      <BuildableProductRunnable
-         runnableDebuggingMode = "0">
+      <RemoteRunnable
+         runnableDebuggingMode = "2"
+         BundleIdentifier = "com.apple.Carousel"
+         RemotePath = "/Eatery">
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "5D05FF3123C2C14400EF8CC9"
@@ -84,7 +88,16 @@
             BlueprintName = "Eatery Watch App"
             ReferencedContainer = "container:Eatery.xcodeproj">
          </BuildableReference>
-      </BuildableProductRunnable>
+      </RemoteRunnable>
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "5D05FF3123C2C14400EF8CC9"
+            BuildableName = "Eatery Watch App.app"
+            BlueprintName = "Eatery Watch App"
+            ReferencedContainer = "container:Eatery.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
    </ProfileAction>
    <AnalyzeAction
       buildConfiguration = "Debug">

--- a/Eatery.xcodeproj/xcshareddata/xcschemes/Eatery Watch App.xcscheme
+++ b/Eatery.xcodeproj/xcshareddata/xcschemes/Eatery Watch App.xcscheme
@@ -55,8 +55,10 @@
       debugServiceExtension = "internal"
       allowLocationSimulation = "YES"
       notificationPayloadFile = "Eatery Watch App Extension/PushNotificationPayload.apns">
-      <BuildableProductRunnable
-         runnableDebuggingMode = "0">
+      <RemoteRunnable
+         runnableDebuggingMode = "2"
+         BundleIdentifier = "com.apple.Carousel"
+         RemotePath = "/Eatery">
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "5D05FF3123C2C14400EF8CC9"
@@ -64,7 +66,7 @@
             BlueprintName = "Eatery Watch App"
             ReferencedContainer = "container:Eatery.xcodeproj">
          </BuildableReference>
-      </BuildableProductRunnable>
+      </RemoteRunnable>
       <LocationScenarioReference
          identifier = "New York, NY, USA"
          referenceType = "1">
@@ -76,8 +78,10 @@
       savedToolIdentifier = ""
       useCustomWorkingDirectory = "NO"
       debugDocumentVersioning = "YES">
-      <BuildableProductRunnable
-         runnableDebuggingMode = "0">
+      <RemoteRunnable
+         runnableDebuggingMode = "2"
+         BundleIdentifier = "com.apple.Carousel"
+         RemotePath = "/Eatery">
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "5D05FF3123C2C14400EF8CC9"
@@ -85,7 +89,16 @@
             BlueprintName = "Eatery Watch App"
             ReferencedContainer = "container:Eatery.xcodeproj">
          </BuildableReference>
-      </BuildableProductRunnable>
+      </RemoteRunnable>
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "5D05FF3123C2C14400EF8CC9"
+            BuildableName = "Eatery Watch App.app"
+            BlueprintName = "Eatery Watch App"
+            ReferencedContainer = "container:Eatery.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
    </ProfileAction>
    <AnalyzeAction
       buildConfiguration = "Debug">

--- a/Eatery/Controllers/Eateries/Campus/CampusEateriesViewController.swift
+++ b/Eatery/Controllers/Eateries/Campus/CampusEateriesViewController.swift
@@ -263,7 +263,7 @@ extension CampusEateriesViewController: EateriesViewControllerDelegate {
         }
 
         if filters.contains(.favorites) {
-            filteredEateries = filteredEateries.filter { $0.hasFavorite }
+            filteredEateries = filteredEateries.filter { $0.currentlyHasFavorite }
         }
 
         if !filters.isDisjoint(with: Filter.areaFilters) {


### PR DESCRIPTION
Fix bug where brunch hours were not being reflected as both lunch and dinner in the "hours this week" view. 

HoursThisWeekView is accessed by opening an eatery then tapping on the header view to see hours for the entire week.

This was done by merging the logic that used to reside in the lookahead view controller into the CampusEatery class.