### PR TITLE
Extended Menu Redesign Pt.1

### DIFF
--- a/Eatery.xcodeproj/project.pbxproj
+++ b/Eatery.xcodeproj/project.pbxproj
@@ -1908,7 +1908,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				COPY_PHASE_STRIP = NO;
 				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = N85YZLFRGD;
+				DEVELOPMENT_TEAM = ZGMCXU7X3U;
 				EXCLUDED_ARCHS = "";
 				"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = arm64;
 				FRAMEWORK_SEARCH_PATHS = "$(inherited)";
@@ -2086,7 +2086,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				COPY_PHASE_STRIP = NO;
 				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = N85YZLFRGD;
+				DEVELOPMENT_TEAM = ZGMCXU7X3U;
 				EXCLUDED_ARCHS = "";
 				"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = arm64;
 				FRAMEWORK_SEARCH_PATHS = "$(inherited)";
@@ -2171,7 +2171,7 @@
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				COPY_PHASE_STRIP = NO;
 				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = N85YZLFRGD;
+				DEVELOPMENT_TEAM = ZGMCXU7X3U;
 				EXCLUDED_ARCHS = "";
 				"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = arm64;
 				FRAMEWORK_SEARCH_PATHS = "$(inherited)";

--- a/Eatery/Controllers/Eateries/Campus/ScrollableViewController.swift
+++ b/Eatery/Controllers/Eateries/Campus/ScrollableViewController.swift
@@ -71,8 +71,6 @@ class ScrollableViewController: UIViewController {
     private func createTabBarStack() {
         headerContainer = ExpandedHeaderContainer()
         headerContainer.backgroundColor = .white
-        headerContainer.addFilterButtonTarget(self, action: #selector(filterButtonPressed), forEvent: .touchUpInside)
-
         headerContainer.snp.makeConstraints { make in
             make.height.equalTo(58)
         }
@@ -204,17 +202,6 @@ class ScrollableViewController: UIViewController {
         tabBar.select(at: selectionIndex)
     }
 
-    @objc func filterButtonPressed() {
-        headerContainer.filterButtonPressed()
-
-        if headerContainer.getFilterButtonState() != .inactive {
-            hideTabBar()
-        } else {
-            showTabBar()
-            headerContainer.setFilterLabelText(to: "")
-        }
-    }
-
     private func hideTabBar() {
         UIView.animate(withDuration: 0.45) {
             let adjustedPosTabBar = (self.headerContainer.frame.height / 2) - (self.tabBar.frame.height / 2)
@@ -223,13 +210,6 @@ class ScrollableViewController: UIViewController {
             self.tabBar.isUserInteractionEnabled = false
             self.tabBar.center.y = self.headerContainer.center.y + adjustedPosTabBar
             self.menuItemsView.center.y = self.tabBar.center.y + adjustedPosMenuStack
-        }
-
-        if headerContainer.getFilterButtonState() == .hightolow {
-            scrollView?.contentSize.height -= tabBar.frame.height // Does not animate when subtracted
-            switchToHighToLowStack()
-        } else if headerContainer.getFilterButtonState() == .lowtohigh {
-            switchToLowToHighStack()
         }
     }
 
@@ -243,26 +223,6 @@ class ScrollableViewController: UIViewController {
             self.menuItemsView.center.y = self.tabBar.center.y + adjustedPosMenuStack
             self.scrollView?.contentSize.height += self.tabBar.frame.height
         }
-
-        switchToOriginalStack()
-    }
-
-    private func switchToHighToLowStack() {
-        menuItemsView.createHighToLowStackIfNeeded()
-        headerContainer.setFilterLabelText(to: "Highest \u{2794} Lowest")
-        menuItemsView.switchVisibleStack(type: .highToLow)
-    }
-
-    private func switchToLowToHighStack() {
-        menuItemsView.createLowToHighStackIfNeeded()
-        headerContainer.setFilterLabelText(to: "Lowest \u{2794} Highest")
-        menuItemsView.switchVisibleStack(type: .lowToHigh)
-
-    }
-
-    private func switchToOriginalStack() {
-        headerContainer.setFilterLabelText(to: "")
-        menuItemsView.switchVisibleStack(type: .original)
     }
 
     override func viewWillAppear(_ animated: Bool) {

--- a/Eatery/Views/Eateries/EateryScreenViews/ExpandedMenus/ExpandedHeaderContainer.swift
+++ b/Eatery/Views/Eateries/EateryScreenViews/ExpandedMenus/ExpandedHeaderContainer.swift
@@ -10,7 +10,6 @@ import UIKit
 
 class ExpandedHeaderContainer: UIView {
 
-//    private var filterButton: ExpandedFilterButton!
     private var filterLabel: UILabel!
     private var separatorView: SeparatorView!
 

--- a/Eatery/Views/Eateries/EateryScreenViews/ExpandedMenus/ExpandedHeaderContainer.swift
+++ b/Eatery/Views/Eateries/EateryScreenViews/ExpandedMenus/ExpandedHeaderContainer.swift
@@ -10,7 +10,7 @@ import UIKit
 
 class ExpandedHeaderContainer: UIView {
 
-    private var filterButton: ExpandedFilterButton!
+//    private var filterButton: ExpandedFilterButton!
     private var filterLabel: UILabel!
     private var separatorView: SeparatorView!
 
@@ -26,17 +26,6 @@ class ExpandedHeaderContainer: UIView {
         titleLabel.preservesSuperviewLayoutMargins = true
         addSubview(titleLabel)
 
-        filterButton = ExpandedFilterButton(frame: .zero, inactiveColor: .systemGray, activeColor: .eateryBlue)
-        filterButton.preservesSuperviewLayoutMargins = true
-        addSubview(filterButton)
-
-        filterLabel = UILabel()
-        filterLabel.textColor = .eateryBlue
-        filterLabel.font = .boldSystemFont(ofSize: 11)
-        filterLabel.text = ""
-        filterLabel.preservesSuperviewLayoutMargins = true
-        addSubview(filterLabel)
-
         separatorView = SeparatorView(insets: UIEdgeInsets(top: 0, left: 0, bottom: 0, right: 0))
         separatorView.tintColor = .clear
         separatorView.isHidden = true
@@ -48,18 +37,6 @@ class ExpandedHeaderContainer: UIView {
             make.bottom.equalToSuperview()
         }
 
-        filterButton.snp.makeConstraints { make in
-            make.centerY.equalTo(titleLabel.snp.centerY)
-            make.height.equalTo(titleLabel.snp.height).multipliedBy(0.3)
-            make.trailing.equalToSuperview().offset(-tabBarPadding)
-            make.width.equalTo(filterButton.snp.height).multipliedBy(1.7)
-        }
-
-        filterLabel.snp.makeConstraints { make in
-            make.centerY.equalTo(titleLabel.snp.centerY)
-            make.trailing.equalTo(filterButton.snp.leading).offset(-6)
-        }
-
         separatorView.snp.makeConstraints { make in
             make.leading.trailing.bottom.equalToSuperview()
         }
@@ -67,22 +44,6 @@ class ExpandedHeaderContainer: UIView {
 
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
-    }
-
-    func addFilterButtonTarget(_ target: Any?, action: Selector, forEvent: UIControlEvents) {
-        filterButton.addTarget(target, action: action, for: forEvent)
-    }
-
-    func filterButtonPressed() {
-        filterButton.pressed()
-    }
-
-    func getFilterButtonState() -> ExpandedFilterButtonState {
-        filterButton.filterState
-    }
-
-    func setFilterLabelText(to text: String) {
-        filterLabel.text = text
     }
 
     func setSeparatorViewHidden(to hidden: Bool) {

--- a/Eatery/Views/Eateries/EateryScreenViews/ExpandedMenus/ExpandedMenuCategoryView.swift
+++ b/Eatery/Views/Eateries/EateryScreenViews/ExpandedMenus/ExpandedMenuCategoryView.swift
@@ -1,5 +1,5 @@
 //
-//  CampusEateryExtendedMenuViewController.swift
+//  ExpandedMenuCategoryView.swift
 //  Eatery
 //
 //  Created by Sergio Diaz on 12/20/20.
@@ -13,6 +13,7 @@ class ExpandedMenuCategoryView: UIView {
     let eatery: CampusEatery!
     let category: String!
     let menu: [ExpandedMenu.Item]!
+    let categoryLabel: UILabel!
 
     /// Public variable that allows other VCs to easily get height of this view
     var contentHeight: CGFloat = 0
@@ -36,11 +37,26 @@ class ExpandedMenuCategoryView: UIView {
         stackView.spacing = 0
         stackView.axis = .vertical
 
+        categoryLabel = UILabel()
+        categoryLabel.text = category
+        categoryLabel.font = .systemFont(ofSize: 18)
+
         super.init(frame: .zero)
+        backgroundColor = .white
+
+        addSubview(categoryLabel)
+        categoryLabel.snp.makeConstraints { make in
+            make.top.equalToSuperview().offset(12)
+            make.leading.equalToSuperview().offset(16)
+            make.trailing.equalToSuperview()
+        }
 
         addSubview(stackView)
         stackView.snp.makeConstraints { make in
-            make.edges.equalToSuperview()
+            make.top.equalTo(categoryLabel.snp.bottom).offset(12)
+            make.leading.equalToSuperview()
+            make.trailing.equalToSuperview()
+            make.bottom.equalToSuperview()
         }
 
     }

--- a/Eatery/Views/Eateries/EateryScreenViews/ExpandedMenus/ExpandedMenuCategoryView.swift
+++ b/Eatery/Views/Eateries/EateryScreenViews/ExpandedMenus/ExpandedMenuCategoryView.swift
@@ -39,7 +39,7 @@ class ExpandedMenuCategoryView: UIView {
 
         categoryLabel = UILabel()
         categoryLabel.text = category
-        categoryLabel.font = .systemFont(ofSize: 18)
+        categoryLabel.font = .systemFont(ofSize: 18, weight: .semibold)
 
         super.init(frame: .zero)
         backgroundColor = .white
@@ -53,7 +53,7 @@ class ExpandedMenuCategoryView: UIView {
 
         addSubview(stackView)
         stackView.snp.makeConstraints { make in
-            make.top.equalTo(categoryLabel.snp.bottom).offset(12)
+            make.top.equalTo(categoryLabel.snp.bottom).offset(4)
             make.leading.equalToSuperview()
             make.trailing.equalToSuperview()
             make.bottom.equalToSuperview()

--- a/Eatery/Views/Eateries/EateryScreenViews/ExpandedMenus/ExpandedMenuItemsView.swift
+++ b/Eatery/Views/Eateries/EateryScreenViews/ExpandedMenus/ExpandedMenuItemsView.swift
@@ -28,6 +28,8 @@ class ExpandedMenuItemView: UIView {
         self.allMenuItems = allMenuItems
 
         menuItemsStack = UIStackView(arrangedSubviews: views)
+        menuItemsStack.spacing = 8
+        menuItemsStack.backgroundColor = .wash
         menuItemsStack.axis = .vertical
         addSubview(menuItemsStack)
 

--- a/Eatery/Views/Eateries/EateryScreenViews/ExpandedMenus/ExpandedMenuRow.swift
+++ b/Eatery/Views/Eateries/EateryScreenViews/ExpandedMenus/ExpandedMenuRow.swift
@@ -54,7 +54,7 @@ class ExpandedMenuRow: UIView {
 
         separator.snp.makeConstraints { make in
             make.height.equalTo(1)
-            make.top.equalToSuperview()
+            make.bottom.equalToSuperview()
             make.leading.equalToSuperview().offset(padding - lineOffset)
             make.trailing.equalToSuperview().offset(-padding + lineOffset)
         }


### PR DESCRIPTION
## Overview

This is the first of many PRs to come that are leading up to the Eatery redesign. This PR focuses on the fixes to Extended Menu


## Changes Made

- Seperate menu items by category
- Update tabscroll animations to correspond to new headers
- Remove sort feature


## Test Coverage

Tested on iPhone 13, iPhone 12 and actual device (XR)


## Next Steps (delete if not applicable)

- After backend updates endpoint, will modify ExtendedMenuRow to support menu items that have detailed descriptions (new addition in redesign)


## Screenshots (delete if not applicable)

<details>

  <summary>Screen Recording</summary>

  https://user-images.githubusercontent.com/57964367/142704749-eb546462-ef81-4770-87a4-7c6a647d9287.MP4 

</details>
